### PR TITLE
geom_alt props

### DIFF
--- a/data/421/174/007/421174007.geojson
+++ b/data/421/174/007/421174007.geojson
@@ -245,6 +245,9 @@
     },
     "wof:country":"YE",
     "wof:created":1459009017,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19f0d9848980574da56e8e09d643772c",
     "wof:hierarchy":[
         {
@@ -255,7 +258,7 @@
         }
     ],
     "wof:id":421174007,
-    "wof:lastmodified":1566660447,
+    "wof:lastmodified":1582331101,
     "wof:name":"Zabid",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/421/183/315/421183315.geojson
+++ b/data/421/183/315/421183315.geojson
@@ -129,6 +129,9 @@
     },
     "wof:country":"YE",
     "wof:created":1459009365,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a07a58eb32cb15d8747813fae0330c39",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":421183315,
-    "wof:lastmodified":1566660449,
+    "wof:lastmodified":1582331101,
     "wof:name":"Bajil",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/421/202/517/421202517.geojson
+++ b/data/421/202/517/421202517.geojson
@@ -152,6 +152,9 @@
     },
     "wof:country":"YE",
     "wof:created":1459010120,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da787364f7d307b071b7d010ccc9796a",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":421202517,
-    "wof:lastmodified":1566660446,
+    "wof:lastmodified":1582331100,
     "wof:name":"Bayt Al Faqiah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/421/203/883/421203883.geojson
+++ b/data/421/203/883/421203883.geojson
@@ -594,6 +594,9 @@
     },
     "wof:country":"YE",
     "wof:created":1459010167,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd40703716c2564f84499074b5bb7e1a",
     "wof:hierarchy":[
         {
@@ -612,7 +615,7 @@
         }
     ],
     "wof:id":421203883,
-    "wof:lastmodified":1566660446,
+    "wof:lastmodified":1582331100,
     "wof:name":"Sana'a",
     "wof:parent_id":85681029,
     "wof:placetype":"locality",

--- a/data/856/324/99/85632499.geojson
+++ b/data/856/324/99/85632499.geojson
@@ -958,7 +958,6 @@
     "src:geom_alt":[
         "naturalearth",
         "meso",
-        "naturalearth",
         "quattroshapes"
     ],
     "src:geom_via":"meso",
@@ -1036,7 +1035,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582331074,
+    "wof:lastmodified":1583213807,
     "wof:name":"Yemen",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/99/85632499.geojson
+++ b/data/856/324/99/85632499.geojson
@@ -956,9 +956,10 @@
     "reversegeo:geometry":"85632499-alt-quattroshapes.geojson",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes",
+        "naturalearth",
         "meso",
-        "naturalearth"
+        "naturalearth",
+        "quattroshapes"
     ],
     "src:geom_via":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -1015,6 +1016,12 @@
     },
     "wof:country":"YE",
     "wof:country_alpha3":"YEM",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth",
+        "quattroshapes"
+    ],
     "wof:geomhash":"168d69a42160157e70b32b01a3db9688",
     "wof:hierarchy":[
         {
@@ -1029,7 +1036,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658454,
+    "wof:lastmodified":1582331074,
     "wof:name":"Yemen",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/809/55/85680955.geojson
+++ b/data/856/809/55/85680955.geojson
@@ -347,6 +347,9 @@
         "wd:id":"Q275732"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69ad960386388a9c9475a2bad49606a7",
     "wof:hierarchy":[
         {
@@ -362,7 +365,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658458,
+    "wof:lastmodified":1582331076,
     "wof:name":"Sa`dah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/59/85680959.geojson
+++ b/data/856/809/59/85680959.geojson
@@ -307,6 +307,9 @@
         "wd:id":"Q275755"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ca366df86b187eabdbbaf54631f60599",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658456,
+    "wof:lastmodified":1582331075,
     "wof:name":"Al Hudaydah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/65/85680965.geojson
+++ b/data/856/809/65/85680965.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Al Mahwit Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"088c91a9544ea9a6cad676be18d72126",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658457,
+    "wof:lastmodified":1582331076,
     "wof:name":"Al Mahwit",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/69/85680969.geojson
+++ b/data/856/809/69/85680969.geojson
@@ -318,6 +318,9 @@
         "wd:id":"Q328193"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"364de66e4a6ce38061b358a587cca21b",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658456,
+    "wof:lastmodified":1582331075,
     "wof:name":"Dhamar",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/73/85680973.geojson
+++ b/data/856/809/73/85680973.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Hajjah Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08de6b6878062afa13f694dda75671ef",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658457,
+    "wof:lastmodified":1582331076,
     "wof:name":"Hajjah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/77/85680977.geojson
+++ b/data/856/809/77/85680977.geojson
@@ -337,6 +337,9 @@
         "wk:page":"'Amran Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"808168e3311db7cce27ff819fdff9978",
     "wof:hierarchy":[
         {
@@ -352,7 +355,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658458,
+    "wof:lastmodified":1582331076,
     "wof:name":"Amran",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/79/85680979.geojson
+++ b/data/856/809/79/85680979.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Ibb Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2a8714e93aaac13cac460b90e6c6bf8b",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658458,
+    "wof:lastmodified":1582331076,
     "wof:name":"Ibb",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/85/85680985.geojson
+++ b/data/856/809/85/85680985.geojson
@@ -261,6 +261,9 @@
         "wk:page":"Lahij Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f4aa4414fda2d1808bffc07b74478a16",
     "wof:hierarchy":[
         {
@@ -276,7 +279,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658458,
+    "wof:lastmodified":1582331076,
     "wof:name":"Lahij",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/89/85680989.geojson
+++ b/data/856/809/89/85680989.geojson
@@ -312,6 +312,9 @@
         "wd:id":"Q388330"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"69e745936080eac7f41f2278b645b542",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658457,
+    "wof:lastmodified":1582331075,
     "wof:name":"Ta`izz",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/95/85680995.geojson
+++ b/data/856/809/95/85680995.geojson
@@ -307,6 +307,9 @@
         "wk:page":"Al Mahrah Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"19c2bc9d0b104786cb5f2e98c05456c6",
     "wof:hierarchy":[
         {
@@ -322,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658456,
+    "wof:lastmodified":1582331075,
     "wof:name":"Al Mahrah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/01/85681001.geojson
+++ b/data/856/810/01/85681001.geojson
@@ -327,6 +327,9 @@
         "wd:id":"Q221212"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d960957c97b109198911af120c18bc0b",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658453,
+    "wof:lastmodified":1582331074,
     "wof:name":"Al Bayda'",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/03/85681003.geojson
+++ b/data/856/810/03/85681003.geojson
@@ -145,6 +145,9 @@
         "iso:id":"YE-DA"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b6200eb580d466fce81325520be0b2ec",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658451,
+    "wof:lastmodified":1582331073,
     "wof:name":"Al Dali'",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/07/85681007.geojson
+++ b/data/856/810/07/85681007.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Al Jawf Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6546e6f8dea5e3ab62087de2ce00c4b3",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658452,
+    "wof:lastmodified":1582331073,
     "wof:name":"Al Jawf",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/11/85681011.geojson
+++ b/data/856/810/11/85681011.geojson
@@ -321,6 +321,9 @@
         "wd:id":"Q328180"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b0b1532c6972fc9e2bdf9f9390a0e980",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658452,
+    "wof:lastmodified":1582331073,
     "wof:name":"Shabwah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/15/85681015.geojson
+++ b/data/856/810/15/85681015.geojson
@@ -380,6 +380,9 @@
         "wd:id":"Q498465"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92cc9c781ab6cf4a929ef02025a00eec",
     "wof:hierarchy":[
         {
@@ -395,7 +398,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658453,
+    "wof:lastmodified":1582331074,
     "wof:name":"Ma'rib",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/21/85681021.geojson
+++ b/data/856/810/21/85681021.geojson
@@ -262,6 +262,9 @@
         "wd:id":"Q388291"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a64d913ca2de6348f209f5f27b954179",
     "wof:hierarchy":[
         {
@@ -277,7 +280,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658452,
+    "wof:lastmodified":1582331073,
     "wof:name":"Sana'a",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/25/85681025.geojson
+++ b/data/856/810/25/85681025.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Hadhramaut Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4fdb46133948a1a6858b3a1418100eb1",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658454,
+    "wof:lastmodified":1582331074,
     "wof:name":"Hadramawt",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/29/85681029.geojson
+++ b/data/856/810/29/85681029.geojson
@@ -140,6 +140,9 @@
         "qs_pg:id":892970
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dd40703716c2564f84499074b5bb7e1a",
     "wof:hierarchy":[
         {
@@ -155,7 +158,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658452,
+    "wof:lastmodified":1582331073,
     "wof:name":"Amanat Al Asimah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/33/85681033.geojson
+++ b/data/856/810/33/85681033.geojson
@@ -316,6 +316,9 @@
         "wd:id":"Q475033"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b5ed9af0ee490f0a8d65e67560b8f633",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658451,
+    "wof:lastmodified":1582331073,
     "wof:name":"Raymah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/39/85681039.geojson
+++ b/data/856/810/39/85681039.geojson
@@ -300,6 +300,9 @@
         "wd:id":"Q275729"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1fc917c927c48e00d51c356637b99e3a",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658453,
+    "wof:lastmodified":1582331074,
     "wof:name":"`Adan",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/43/85681043.geojson
+++ b/data/856/810/43/85681043.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Abyan Governorate"
     },
     "wof:country":"YE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1ebace65fedb0af37f4ec691e40a21be",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566658452,
+    "wof:lastmodified":1582331073,
     "wof:name":"Abyan",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/890/413/525/890413525.geojson
+++ b/data/890/413/525/890413525.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051003,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e1fd9603c0c2fd82d867afa99cb9f02",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890413525,
-    "wof:lastmodified":1566660618,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al Mishb\u0101b",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/413/571/890413571.geojson
+++ b/data/890/413/571/890413571.geojson
@@ -46,6 +46,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051005,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c2a2a995920cd48179cc29d15e69b33",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890413571,
-    "wof:lastmodified":1534379828,
+    "wof:lastmodified":1582331106,
     "wof:name":"Az\u0327 Z\u0327ih\u0101r",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/413/593/890413593.geojson
+++ b/data/890/413/593/890413593.geojson
@@ -191,6 +191,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051005,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2d05981776ced4ea4302200a290bc0ab",
     "wof:hierarchy":[
         {
@@ -202,7 +205,7 @@
         }
     ],
     "wof:id":890413593,
-    "wof:lastmodified":1566660596,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Jufrah",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/413/673/890413673.geojson
+++ b/data/890/413/673/890413673.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051010,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4f5c1084d6dfa2131a8bdc0eb688e093",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890413673,
-    "wof:lastmodified":1566660601,
+    "wof:lastmodified":1582331106,
     "wof:name":"Ar Radim",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/413/685/890413685.geojson
+++ b/data/890/413/685/890413685.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051010,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"458ab8262d89f07cb8f65ffe0c77f90e",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890413685,
-    "wof:lastmodified":1566660612,
+    "wof:lastmodified":1582331106,
     "wof:name":"Dhaw\u0101t al \u2018Arsh",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/413/759/890413759.geojson
+++ b/data/890/413/759/890413759.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051013,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c7803031a6322cf32855074dc4c6acbc",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890413759,
-    "wof:lastmodified":1566660610,
+    "wof:lastmodified":1582331106,
     "wof:name":"W\u0101d\u012b Ban\u012b \u2018Umar",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/413/799/890413799.geojson
+++ b/data/890/413/799/890413799.geojson
@@ -49,6 +49,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051014,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc0113ef40b719543e491b7eb7d87713",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":890413799,
-    "wof:lastmodified":1566660596,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Maghribah",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/413/849/890413849.geojson
+++ b/data/890/413/849/890413849.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051016,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4628c5ff043644c39e056abaf00bc8e2",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890413849,
-    "wof:lastmodified":1566660613,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al Mashab",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/413/861/890413861.geojson
+++ b/data/890/413/861/890413861.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051017,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b6a1481d7235c9d1e2b89c8c222f6b58",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890413861,
-    "wof:lastmodified":1566660602,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al Q\u012bmah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/413/881/890413881.geojson
+++ b/data/890/413/881/890413881.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051018,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dedb5fa81c732662ab3c8162af1350e0",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890413881,
-    "wof:lastmodified":1566660601,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al \u2018Uly\u0101",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/413/899/890413899.geojson
+++ b/data/890/413/899/890413899.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051019,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a345ed61861ad580f68fec4fff22aace",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890413899,
-    "wof:lastmodified":1566660616,
+    "wof:lastmodified":1582331106,
     "wof:name":"Zamzam",
     "wof:parent_id":1091922781,
     "wof:placetype":"locality",

--- a/data/890/413/909/890413909.geojson
+++ b/data/890/413/909/890413909.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051020,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"007acd89d99f626307697fcefb5bc9c7",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890413909,
-    "wof:lastmodified":1566660595,
+    "wof:lastmodified":1582331105,
     "wof:name":"\u0100l J\u0101bir",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/413/951/890413951.geojson
+++ b/data/890/413/951/890413951.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051026,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"119069a27d54b9b1d8101980497f0390",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890413951,
-    "wof:lastmodified":1566660610,
+    "wof:lastmodified":1582331106,
     "wof:name":"A\u015f \u015e\u0101f\u012byah",
     "wof:parent_id":1091920841,
     "wof:placetype":"locality",

--- a/data/890/413/993/890413993.geojson
+++ b/data/890/413/993/890413993.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051028,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac75b7e577ec1b59fd8737ea25cc8735",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890413993,
-    "wof:lastmodified":1566660609,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al \u2018Araq",
     "wof:parent_id":1091920841,
     "wof:placetype":"locality",

--- a/data/890/414/013/890414013.geojson
+++ b/data/890/414/013/890414013.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051029,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d68f7109d1e62c2d8895775a3477b64",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890414013,
-    "wof:lastmodified":1566660630,
+    "wof:lastmodified":1582331106,
     "wof:name":"\u0100l \u015e\u0101li\u1e29 Bin N\u0101\u015fir",
     "wof:parent_id":1091920841,
     "wof:placetype":"locality",

--- a/data/890/414/025/890414025.geojson
+++ b/data/890/414/025/890414025.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051029,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c719a785cfd024388f43d0521c62afa9",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890414025,
-    "wof:lastmodified":1566660631,
+    "wof:lastmodified":1582331106,
     "wof:name":"Al Mabrak",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/414/089/890414089.geojson
+++ b/data/890/414/089/890414089.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051031,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b919cc931ab56c367d0f729ab9818ce4",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890414089,
-    "wof:lastmodified":1566660652,
+    "wof:lastmodified":1582331106,
     "wof:name":"Ar Rab\u2018",
     "wof:parent_id":1091925199,
     "wof:placetype":"locality",

--- a/data/890/414/331/890414331.geojson
+++ b/data/890/414/331/890414331.geojson
@@ -45,6 +45,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051044,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ae16be1b3fbcd47df25924ddd80cfc2",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890414331,
-    "wof:lastmodified":1566660622,
+    "wof:lastmodified":1582331106,
     "wof:name":"Az Zaylah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/414/877/890414877.geojson
+++ b/data/890/414/877/890414877.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051065,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cbef52c77b8fe604d044f35612e7261f",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890414877,
-    "wof:lastmodified":1566660653,
+    "wof:lastmodified":1582331106,
     "wof:name":"Qarn al Kharaf",
     "wof:parent_id":1091921677,
     "wof:placetype":"locality",

--- a/data/890/415/037/890415037.geojson
+++ b/data/890/415/037/890415037.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051071,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52eb41e7446bf61f9ca8cb78d24c0188",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890415037,
-    "wof:lastmodified":1566660771,
+    "wof:lastmodified":1582331108,
     "wof:name":"Ad Dimnah",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/417/361/890417361.geojson
+++ b/data/890/417/361/890417361.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051198,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb5e08e8f13ebfc790dcb6be80d6dad4",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890417361,
-    "wof:lastmodified":1566661216,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Ma\u1e29wal",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/417/379/890417379.geojson
+++ b/data/890/417/379/890417379.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051199,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5a96895308f9163c53966feadf5ba04",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890417379,
-    "wof:lastmodified":1566661213,
+    "wof:lastmodified":1582331113,
     "wof:name":"An Najd",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/417/387/890417387.geojson
+++ b/data/890/417/387/890417387.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051199,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5f610526c8c765619926649446dce0a5",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890417387,
-    "wof:lastmodified":1566661224,
+    "wof:lastmodified":1582331113,
     "wof:name":"Ar Ruk\u016bb",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/417/519/890417519.geojson
+++ b/data/890/417/519/890417519.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051207,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f74d6752e1390897ca4f19729bb058d9",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890417519,
-    "wof:lastmodified":1566661214,
+    "wof:lastmodified":1582331113,
     "wof:name":"Ar R\u0101\u1e29ah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/417/585/890417585.geojson
+++ b/data/890/417/585/890417585.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051211,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a4382dd326484a134811813aa38d7e07",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890417585,
-    "wof:lastmodified":1566661223,
+    "wof:lastmodified":1582331113,
     "wof:name":"An Niy\u0101bah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/417/607/890417607.geojson
+++ b/data/890/417/607/890417607.geojson
@@ -43,6 +43,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051212,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30feca5889839a49dd9d4a2e7b7fd230",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":890417607,
-    "wof:lastmodified":1534379832,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Q\u0101\u2018idah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/417/609/890417609.geojson
+++ b/data/890/417/609/890417609.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051212,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc8980575867ccd2ddb20d8b7a8cef97",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890417609,
-    "wof:lastmodified":1566661222,
+    "wof:lastmodified":1582331113,
     "wof:name":"\u2018Azz\u0101n",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/417/631/890417631.geojson
+++ b/data/890/417/631/890417631.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051213,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1088c7aa5f0b5f87209f8b268fb792c",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890417631,
-    "wof:lastmodified":1566661222,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Qayyim",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/417/635/890417635.geojson
+++ b/data/890/417/635/890417635.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051213,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c1e07fa30df7c7bacb3e965bfbed716",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890417635,
-    "wof:lastmodified":1566661212,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Ma\u2018nibah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/417/663/890417663.geojson
+++ b/data/890/417/663/890417663.geojson
@@ -46,6 +46,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051214,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25029ef3031560367e452227f8811837",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890417663,
-    "wof:lastmodified":1534379834,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Gh\u0101rib",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/417/737/890417737.geojson
+++ b/data/890/417/737/890417737.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051218,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"700f6ebea87c12fa7483f8b1e7626963",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890417737,
-    "wof:lastmodified":1566661207,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Kha\u1e11r\u0101\u2019",
     "wof:parent_id":1091925391,
     "wof:placetype":"locality",

--- a/data/890/417/765/890417765.geojson
+++ b/data/890/417/765/890417765.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051219,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fbcc80636ce22425e4004ef25c1fac71",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890417765,
-    "wof:lastmodified":1566661207,
+    "wof:lastmodified":1582331113,
     "wof:name":"Mas\u2018\u016bdah",
     "wof:parent_id":1091925391,
     "wof:placetype":"locality",

--- a/data/890/418/045/890418045.geojson
+++ b/data/890/418/045/890418045.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051232,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d5b636f32778780633bc7cb3842162f",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890418045,
-    "wof:lastmodified":1566661302,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Ashr\u0101f",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/418/329/890418329.geojson
+++ b/data/890/418/329/890418329.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051244,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"453b167f0af97a05e69f0e9a74a428ea",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890418329,
-    "wof:lastmodified":1566661313,
+    "wof:lastmodified":1582331114,
     "wof:name":"Ash Sha\u2018\u0101r",
     "wof:parent_id":1091925415,
     "wof:placetype":"locality",

--- a/data/890/418/643/890418643.geojson
+++ b/data/890/418/643/890418643.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051256,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ecff7b44ce2a4a08d96c686d1eda7c8d",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890418643,
-    "wof:lastmodified":1566661283,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al \u1e28aqlah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/418/691/890418691.geojson
+++ b/data/890/418/691/890418691.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051258,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b03c7079c8957cbf754f9cb5c33594bb",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890418691,
-    "wof:lastmodified":1566661310,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Qayyimah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/418/721/890418721.geojson
+++ b/data/890/418/721/890418721.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051259,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d5b56d90dbb6028ec6a8cf1518e27a83",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890418721,
-    "wof:lastmodified":1566661314,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al \u1e28awlah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/418/747/890418747.geojson
+++ b/data/890/418/747/890418747.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051260,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f9ef18c89245b5d1f215b14330687d3",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890418747,
-    "wof:lastmodified":1566661294,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Khir\u0101bah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/418/757/890418757.geojson
+++ b/data/890/418/757/890418757.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051260,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02ef3f769c08af8a20bad59d745292b0",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890418757,
-    "wof:lastmodified":1566661301,
+    "wof:lastmodified":1582331114,
     "wof:name":"Ad Dammin",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/418/769/890418769.geojson
+++ b/data/890/418/769/890418769.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051261,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"834e88ddf6f00e7608d244f73a45a7b0",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890418769,
-    "wof:lastmodified":1566661299,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Bid\u0101\u1e29",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/418/865/890418865.geojson
+++ b/data/890/418/865/890418865.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051264,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bf3ae8f3cbd90ff67c45eccadaa5c412",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890418865,
-    "wof:lastmodified":1566661309,
+    "wof:lastmodified":1582331114,
     "wof:name":"Sha\u2018b al Bin",
     "wof:parent_id":1091923483,
     "wof:placetype":"locality",

--- a/data/890/418/889/890418889.geojson
+++ b/data/890/418/889/890418889.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051265,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"56b1b77e6a96dec53301023df5682b18",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890418889,
-    "wof:lastmodified":1566661284,
+    "wof:lastmodified":1582331114,
     "wof:name":"\u1e28ufayl\u0101 Sha\u2018b al \u2018Araj",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/418/949/890418949.geojson
+++ b/data/890/418/949/890418949.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051267,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e13f85adb0976a45bebfba23bcf6e52",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890418949,
-    "wof:lastmodified":1566661296,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al \u2018I\u015f\u0101bah",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/418/953/890418953.geojson
+++ b/data/890/418/953/890418953.geojson
@@ -52,6 +52,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051267,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a278e7441439e1b64eac08967d9e345",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890418953,
-    "wof:lastmodified":1566661279,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Mi\u2018z\u0101b",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/419/139/890419139.geojson
+++ b/data/890/419/139/890419139.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051274,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"871b8ed952c2c48a16434134890f4f25",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890419139,
-    "wof:lastmodified":1566661066,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al \u1e28azm",
     "wof:parent_id":1091920749,
     "wof:placetype":"locality",

--- a/data/890/419/241/890419241.geojson
+++ b/data/890/419/241/890419241.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051279,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52f6e021745ba32dfd14123b8217679c",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890419241,
-    "wof:lastmodified":1566661069,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al \u2018\u0100ri\u1e11ah",
     "wof:parent_id":1091923769,
     "wof:placetype":"locality",

--- a/data/890/419/427/890419427.geojson
+++ b/data/890/419/427/890419427.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051287,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"717cc0b3f4b6dd388431ebeed870f339",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890419427,
-    "wof:lastmodified":1566661073,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Marwah",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/419/773/890419773.geojson
+++ b/data/890/419/773/890419773.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051301,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd4bd096acf892cc3b08465500a5b563",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890419773,
-    "wof:lastmodified":1566661086,
+    "wof:lastmodified":1582331111,
     "wof:name":"Qash\u2018 al Mawsi\u0163ah",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/419/837/890419837.geojson
+++ b/data/890/419/837/890419837.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051304,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4118edd82f17139a8ec4ca8dd1cff0c8",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890419837,
-    "wof:lastmodified":1566661078,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Khirbah",
     "wof:parent_id":1091919167,
     "wof:placetype":"locality",

--- a/data/890/419/951/890419951.geojson
+++ b/data/890/419/951/890419951.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051308,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f87c47020995c723c1890678f80fcfeb",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890419951,
-    "wof:lastmodified":1566661066,
+    "wof:lastmodified":1582331111,
     "wof:name":"Ash Sh\u0101jibah",
     "wof:parent_id":1091926555,
     "wof:placetype":"locality",

--- a/data/890/420/627/890420627.geojson
+++ b/data/890/420/627/890420627.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051355,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0510ea68d280fcdf104088edacd1a2c",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890420627,
-    "wof:lastmodified":1566661255,
+    "wof:lastmodified":1582331114,
     "wof:name":"An Naj\u0101d",
     "wof:parent_id":1091920811,
     "wof:placetype":"locality",

--- a/data/890/420/695/890420695.geojson
+++ b/data/890/420/695/890420695.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051358,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52c40a7569622348ecc2011c83322928",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890420695,
-    "wof:lastmodified":1566661258,
+    "wof:lastmodified":1582331114,
     "wof:name":"Ash Sha\u2018bah",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/420/735/890420735.geojson
+++ b/data/890/420/735/890420735.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051360,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a8114e2a89279795a8b9433e9869bae2",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890420735,
-    "wof:lastmodified":1566661264,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al \u2018Ashshah",
     "wof:parent_id":1091925417,
     "wof:placetype":"locality",

--- a/data/890/420/771/890420771.geojson
+++ b/data/890/420/771/890420771.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051361,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbf3e817fa24110f79d974df1a3947fa",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890420771,
-    "wof:lastmodified":1566661260,
+    "wof:lastmodified":1582331114,
     "wof:name":"Ash Shaqrah",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/420/871/890420871.geojson
+++ b/data/890/420/871/890420871.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051365,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3b6b740b3d97b77cc31bc4f325af013",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
         }
     ],
     "wof:id":890420871,
-    "wof:lastmodified":1566661268,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Lakimah Bayt \u2018Uds",
     "wof:parent_id":1091921523,
     "wof:placetype":"locality",

--- a/data/890/420/887/890420887.geojson
+++ b/data/890/420/887/890420887.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051365,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4852de5b83d88b43e207be9cfdfa33e8",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890420887,
-    "wof:lastmodified":1566661253,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al Jih\u0101d",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/420/889/890420889.geojson
+++ b/data/890/420/889/890420889.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051365,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4a020a1c86e1208bfbcd2188170209d",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890420889,
-    "wof:lastmodified":1566661253,
+    "wof:lastmodified":1582331113,
     "wof:name":"A\u1e11 \u1e10ayyiq",
     "wof:parent_id":1091922135,
     "wof:placetype":"locality",

--- a/data/890/420/983/890420983.geojson
+++ b/data/890/420/983/890420983.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051369,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f57473d5a4977fa77af7b7ee40f46f44",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890420983,
-    "wof:lastmodified":1566661259,
+    "wof:lastmodified":1582331114,
     "wof:name":"Al \u1e28anakah",
     "wof:parent_id":1091918993,
     "wof:placetype":"locality",

--- a/data/890/421/097/890421097.geojson
+++ b/data/890/421/097/890421097.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051373,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d11b62d047bbe5e1e30dfeddf05a1bea",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890421097,
-    "wof:lastmodified":1566661151,
+    "wof:lastmodified":1582331112,
     "wof:name":"Ar Raddah",
     "wof:parent_id":1091925155,
     "wof:placetype":"locality",

--- a/data/890/421/159/890421159.geojson
+++ b/data/890/421/159/890421159.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051382,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"34201f35ca5c3999822f7a50dc181ff2",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890421159,
-    "wof:lastmodified":1566661142,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Mal\u1e29ah",
     "wof:parent_id":1091926707,
     "wof:placetype":"locality",

--- a/data/890/421/353/890421353.geojson
+++ b/data/890/421/353/890421353.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051389,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81f9a18ee90b34d4f75ac1c336f3351d",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890421353,
-    "wof:lastmodified":1566661142,
+    "wof:lastmodified":1582331112,
     "wof:name":"\u0100l \u2018\u0100mir",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/421/587/890421587.geojson
+++ b/data/890/421/587/890421587.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051399,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"75c2333a2f567f749c7e021c45b1a878",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890421587,
-    "wof:lastmodified":1566661155,
+    "wof:lastmodified":1582331112,
     "wof:name":"Az Zujj",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/421/599/890421599.geojson
+++ b/data/890/421/599/890421599.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051399,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d6a1c3b0083ca55b2c1ddec6d08793f2",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890421599,
-    "wof:lastmodified":1566661156,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Maft\u016bl",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/421/659/890421659.geojson
+++ b/data/890/421/659/890421659.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051402,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2a0b2344c0d9dc0e017d27045257a856",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890421659,
-    "wof:lastmodified":1566661151,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Jaww",
     "wof:parent_id":1091922105,
     "wof:placetype":"locality",

--- a/data/890/423/047/890423047.geojson
+++ b/data/890/423/047/890423047.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051478,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f925ae4b2ddd37b28c86662de1afb045",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890423047,
-    "wof:lastmodified":1566660816,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al \u2018Ar\u012bsh",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/423/051/890423051.geojson
+++ b/data/890/423/051/890423051.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051478,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81324da102249782a41c1f35c589e9b9",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423051,
-    "wof:lastmodified":1566660837,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Kawmah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/423/071/890423071.geojson
+++ b/data/890/423/071/890423071.geojson
@@ -43,6 +43,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051479,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b952bdd0873ecedfd8626660957b21ca",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":890423071,
-    "wof:lastmodified":1534379832,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Maghribah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/423/075/890423075.geojson
+++ b/data/890/423/075/890423075.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051479,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d7e6cc50e903d8578f205cc7f8825095",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890423075,
-    "wof:lastmodified":1566660831,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al \u2018Ariq",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/423/099/890423099.geojson
+++ b/data/890/423/099/890423099.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051480,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b676a944dcb4827baa6a7b3efd598d88",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423099,
-    "wof:lastmodified":1566660819,
+    "wof:lastmodified":1582331108,
     "wof:name":"Ash Sharq\u012b",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/423/117/890423117.geojson
+++ b/data/890/423/117/890423117.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051481,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d551d4c16f303005a058bd1b8f5dac30",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890423117,
-    "wof:lastmodified":1566660825,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Qaz\u2018ah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/423/125/890423125.geojson
+++ b/data/890/423/125/890423125.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051482,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38cf06e5762a2f3bec9c59dd18c5fe38",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890423125,
-    "wof:lastmodified":1566660840,
+    "wof:lastmodified":1582331109,
     "wof:name":"Ar Rajmah",
     "wof:parent_id":1091923483,
     "wof:placetype":"locality",

--- a/data/890/423/209/890423209.geojson
+++ b/data/890/423/209/890423209.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051485,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb6bae49187e85f388afbac8c11811b7",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423209,
-    "wof:lastmodified":1566660834,
+    "wof:lastmodified":1582331109,
     "wof:name":"An Naq\u012bl",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/423/331/890423331.geojson
+++ b/data/890/423/331/890423331.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051493,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"050893c15342b7258087d0931b8c305d",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423331,
-    "wof:lastmodified":1566660808,
+    "wof:lastmodified":1582331108,
     "wof:name":"Ash Sharf",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/423/401/890423401.geojson
+++ b/data/890/423/401/890423401.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051496,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ca81ee050f44adbdba090d905169b9d",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423401,
-    "wof:lastmodified":1566660817,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Gharb\u012b",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/423/575/890423575.geojson
+++ b/data/890/423/575/890423575.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051504,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"15c8813a93da37e17f0dbdf3c534a740",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890423575,
-    "wof:lastmodified":1566660822,
+    "wof:lastmodified":1582331109,
     "wof:name":"Ad Dumaynah",
     "wof:parent_id":1091924239,
     "wof:placetype":"locality",

--- a/data/890/423/579/890423579.geojson
+++ b/data/890/423/579/890423579.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051504,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"086675ac11c7b92d1743cff25da2ab01",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423579,
-    "wof:lastmodified":1566660840,
+    "wof:lastmodified":1582331109,
     "wof:name":"Ad Darb",
     "wof:parent_id":1091924239,
     "wof:placetype":"locality",

--- a/data/890/423/671/890423671.geojson
+++ b/data/890/423/671/890423671.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051508,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2d1df37c01fed7fa25522ee1cec5e7a",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890423671,
-    "wof:lastmodified":1566660830,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al \u1e28adibah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/424/425/890424425.geojson
+++ b/data/890/424/425/890424425.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051544,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5411d3222e91b6a1cdf99ca7c915e2f3",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424425,
-    "wof:lastmodified":1566660781,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Jurb",
     "wof:parent_id":1091923743,
     "wof:placetype":"locality",

--- a/data/890/424/443/890424443.geojson
+++ b/data/890/424/443/890424443.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051544,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"76c77a68829b439a644df425c1484a28",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424443,
-    "wof:lastmodified":1566660798,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Khurshah",
     "wof:parent_id":1091923385,
     "wof:placetype":"locality",

--- a/data/890/424/473/890424473.geojson
+++ b/data/890/424/473/890424473.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051545,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c68497a2391c40d3e3932127eb2105b",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890424473,
-    "wof:lastmodified":1566660800,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al \u1e28\u0101zah",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/424/637/890424637.geojson
+++ b/data/890/424/637/890424637.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051553,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3bc9b7d091f98a65be41ccb7fd7405b",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890424637,
-    "wof:lastmodified":1566660802,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Misl\u0101m Ban\u012b J\u0101bir",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/424/683/890424683.geojson
+++ b/data/890/424/683/890424683.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051556,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a22647e3ede7738928a7e9f1494a4daf",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424683,
-    "wof:lastmodified":1566660801,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Ma\u1e11b\u0101r",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/424/695/890424695.geojson
+++ b/data/890/424/695/890424695.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051557,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"002aba89aebc54e1c7817c8b9c0d2fea",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890424695,
-    "wof:lastmodified":1566660787,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Khabb",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/424/717/890424717.geojson
+++ b/data/890/424/717/890424717.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051559,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc9649f7b4247ed4264c6039faf0d9c4",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890424717,
-    "wof:lastmodified":1566660805,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al \u2018Al\u0101y\u0101",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/424/827/890424827.geojson
+++ b/data/890/424/827/890424827.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051564,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e01207e76708e9253091f008475628e7",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890424827,
-    "wof:lastmodified":1566660780,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Ma\u015fna\u2018ah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/424/849/890424849.geojson
+++ b/data/890/424/849/890424849.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051565,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4680f4cb91e9419d292829ed9ccd2985",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424849,
-    "wof:lastmodified":1566660799,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Qufayl",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/424/923/890424923.geojson
+++ b/data/890/424/923/890424923.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051568,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2960babb86cb618cdcca7e0e50ebd7a0",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424923,
-    "wof:lastmodified":1566660790,
+    "wof:lastmodified":1582331108,
     "wof:name":"Ad Damnah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/424/925/890424925.geojson
+++ b/data/890/424/925/890424925.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051568,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35c4f25e58c5996974574a518678aa91",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890424925,
-    "wof:lastmodified":1566660791,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Qar\u012b\u2018",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/425/005/890425005.geojson
+++ b/data/890/425/005/890425005.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dcf40adcd658a7ccf2d26aa1411f60d5",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890425005,
-    "wof:lastmodified":1566660587,
+    "wof:lastmodified":1582331105,
     "wof:name":"Bayt al \u1e28am\u0101d\u012b",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/425/183/890425183.geojson
+++ b/data/890/425/183/890425183.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051578,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ada61a56c8f916deff6724bbaa64ea02",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890425183,
-    "wof:lastmodified":1566660591,
+    "wof:lastmodified":1582331105,
     "wof:name":"Hir\u0101n",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/425/205/890425205.geojson
+++ b/data/890/425/205/890425205.geojson
@@ -46,6 +46,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051579,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"562f41e9f159c0ea78444cf26def3398",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890425205,
-    "wof:lastmodified":1534379834,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al W\u0101si\u0163",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/425/223/890425223.geojson
+++ b/data/890/425/223/890425223.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051580,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"173ad88039eb6a1be16716717a6de3d8",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890425223,
-    "wof:lastmodified":1566660579,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Qa\u015fabah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/425/283/890425283.geojson
+++ b/data/890/425/283/890425283.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051583,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2ad2304d226fdd02b3be4969c23d4e6",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890425283,
-    "wof:lastmodified":1566660577,
+    "wof:lastmodified":1582331105,
     "wof:name":"Adh Dh\u0101r\u00e1",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/425/325/890425325.geojson
+++ b/data/890/425/325/890425325.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051584,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e1be6a12e132243160fcc1c47a91784",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890425325,
-    "wof:lastmodified":1566660570,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Bay\u1e11\u0101\u2019",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/425/349/890425349.geojson
+++ b/data/890/425/349/890425349.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051585,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c83052dbe097bcc871a05c75510b9b51",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890425349,
-    "wof:lastmodified":1566660568,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Hushaymah",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/425/443/890425443.geojson
+++ b/data/890/425/443/890425443.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051589,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8ae9c90a8a8a14f9ce7f5c7829e2b78",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890425443,
-    "wof:lastmodified":1566660578,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al Jal\u2018ah \u0100l Sham\u2018ah",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/425/513/890425513.geojson
+++ b/data/890/425/513/890425513.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051593,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ba9383872ddefee1ccda07077d92738c",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890425513,
-    "wof:lastmodified":1566660591,
+    "wof:lastmodified":1582331105,
     "wof:name":"Alt ash Shughb\u0101n",
     "wof:parent_id":1091925445,
     "wof:placetype":"locality",

--- a/data/890/425/577/890425577.geojson
+++ b/data/890/425/577/890425577.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051595,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f3e0f8e50ebc85e5e7ec1ed316a0d8e3",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890425577,
-    "wof:lastmodified":1566660593,
+    "wof:lastmodified":1582331105,
     "wof:name":"Ad D\u016br",
     "wof:parent_id":1091920749,
     "wof:placetype":"locality",

--- a/data/890/425/579/890425579.geojson
+++ b/data/890/425/579/890425579.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051595,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"30587794ce05c08b126e83c00307c66b",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890425579,
-    "wof:lastmodified":1566660592,
+    "wof:lastmodified":1582331105,
     "wof:name":"Da\u1e29yah",
     "wof:parent_id":1091920749,
     "wof:placetype":"locality",

--- a/data/890/425/663/890425663.geojson
+++ b/data/890/425/663/890425663.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051599,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"18a4c80b39e17bb7af881d19db228d9c",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890425663,
-    "wof:lastmodified":1566660584,
+    "wof:lastmodified":1582331105,
     "wof:name":"Ar Ra\u2019s",
     "wof:parent_id":1091920841,
     "wof:placetype":"locality",

--- a/data/890/425/673/890425673.geojson
+++ b/data/890/425/673/890425673.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051600,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4d817d3530a5cb6f2abae9e9723debaa",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890425673,
-    "wof:lastmodified":1566660557,
+    "wof:lastmodified":1582331105,
     "wof:name":"Ad Da\u1e29l",
     "wof:parent_id":1091920841,
     "wof:placetype":"locality",

--- a/data/890/425/779/890425779.geojson
+++ b/data/890/425/779/890425779.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051604,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5ba20312c87a3686f82b81d66d4e5b88",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890425779,
-    "wof:lastmodified":1566660570,
+    "wof:lastmodified":1582331105,
     "wof:name":"Sha\u2018b an Najlah",
     "wof:parent_id":1091921649,
     "wof:placetype":"locality",

--- a/data/890/426/321/890426321.geojson
+++ b/data/890/426/321/890426321.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e59eaff8b19018e18d0ff32cafb4c4e5",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890426321,
-    "wof:lastmodified":1566661139,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Ma\u1e11\u1e11ah",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/426/427/890426427.geojson
+++ b/data/890/426/427/890426427.geojson
@@ -281,6 +281,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051631,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d05e3a4a891da7bc766555180160e38b",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":890426427,
-    "wof:lastmodified":1566661127,
+    "wof:lastmodified":1582331112,
     "wof:name":"Ar Raqqah",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/426/485/890426485.geojson
+++ b/data/890/426/485/890426485.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051634,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a15965e743f61299ba70ad671951609c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890426485,
-    "wof:lastmodified":1566661098,
+    "wof:lastmodified":1582331112,
     "wof:name":"As Sawdah",
     "wof:parent_id":1091925497,
     "wof:placetype":"locality",

--- a/data/890/426/679/890426679.geojson
+++ b/data/890/426/679/890426679.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051641,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69705ddfe24f6644bd8090f19f010583",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890426679,
-    "wof:lastmodified":1566661127,
+    "wof:lastmodified":1582331112,
     "wof:name":"As S\u016bq",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/426/725/890426725.geojson
+++ b/data/890/426/725/890426725.geojson
@@ -48,6 +48,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051644,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7aa3c25df046f8e5761badedc0861e5f",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":890426725,
-    "wof:lastmodified":1566661109,
+    "wof:lastmodified":1582331112,
     "wof:name":"As S\u016bq",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/426/887/890426887.geojson
+++ b/data/890/426/887/890426887.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051651,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"10f357a58ecd4bf7f58ae601982d2d47",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890426887,
-    "wof:lastmodified":1566661099,
+    "wof:lastmodified":1582331112,
     "wof:name":"\u0100l Mu\u1e29ammad",
     "wof:parent_id":1091919135,
     "wof:placetype":"locality",

--- a/data/890/427/047/890427047.geojson
+++ b/data/890/427/047/890427047.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051671,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c73e41f79620d147ba7d22d419736c9",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890427047,
-    "wof:lastmodified":1566661330,
+    "wof:lastmodified":1582331115,
     "wof:name":"\u0100l \u2018Umar",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/427/131/890427131.geojson
+++ b/data/890/427/131/890427131.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051676,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d1ea77f502afbf63af0f2c63a979b515",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890427131,
-    "wof:lastmodified":1566661344,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Lujm",
     "wof:parent_id":1091926463,
     "wof:placetype":"locality",

--- a/data/890/427/143/890427143.geojson
+++ b/data/890/427/143/890427143.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051677,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55563973c70a3146588768fe82467767",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890427143,
-    "wof:lastmodified":1566661340,
+    "wof:lastmodified":1582331115,
     "wof:name":"Ash Sha\u2018b",
     "wof:parent_id":1091926463,
     "wof:placetype":"locality",

--- a/data/890/427/167/890427167.geojson
+++ b/data/890/427/167/890427167.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051679,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"461141a590d37af0abd91f818aa296ac",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890427167,
-    "wof:lastmodified":1566661323,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Ghayl",
     "wof:parent_id":1091926463,
     "wof:placetype":"locality",

--- a/data/890/427/329/890427329.geojson
+++ b/data/890/427/329/890427329.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051689,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b437fa131133c23223c4c61453d8a99",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890427329,
-    "wof:lastmodified":1566661362,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Mar\u0101fi\u2018",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/427/399/890427399.geojson
+++ b/data/890/427/399/890427399.geojson
@@ -43,6 +43,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051693,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4bf5ea4259409ea70036ef605dd7251",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":890427399,
-    "wof:lastmodified":1534530970,
+    "wof:lastmodified":1582331115,
     "wof:name":"Adh Dhanabah",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/427/439/890427439.geojson
+++ b/data/890/427/439/890427439.geojson
@@ -43,6 +43,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051695,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81fd78220851a90d91d613f6139b6292",
     "wof:hierarchy":[
         {
@@ -54,7 +57,7 @@
         }
     ],
     "wof:id":890427439,
-    "wof:lastmodified":1534379833,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Hayjah",
     "wof:parent_id":1091925479,
     "wof:placetype":"locality",

--- a/data/890/427/453/890427453.geojson
+++ b/data/890/427/453/890427453.geojson
@@ -79,6 +79,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051696,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f7007c1147c9fe519155b3a634d2b501",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":890427453,
-    "wof:lastmodified":1566661336,
+    "wof:lastmodified":1582331115,
     "wof:name":"As Sawdah",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/427/565/890427565.geojson
+++ b/data/890/427/565/890427565.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051703,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"149712d369b210524a7687def248a0ba",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890427565,
-    "wof:lastmodified":1566661348,
+    "wof:lastmodified":1582331115,
     "wof:name":"A\u015f \u015eulbah",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/427/589/890427589.geojson
+++ b/data/890/427/589/890427589.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051704,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8151fb08d8ac25c371ea21238141e729",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890427589,
-    "wof:lastmodified":1566661342,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Majb\u0101rah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/427/601/890427601.geojson
+++ b/data/890/427/601/890427601.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051705,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a9fc5cacbaf66612832d06c52f94769",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":890427601,
-    "wof:lastmodified":1566661358,
+    "wof:lastmodified":1582331115,
     "wof:name":"\u0100l ar R\u016bs",
     "wof:parent_id":1091925551,
     "wof:placetype":"locality",

--- a/data/890/427/701/890427701.geojson
+++ b/data/890/427/701/890427701.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051711,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1c88c61d11a9b09d55c00e1b2007a1e5",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890427701,
-    "wof:lastmodified":1566661319,
+    "wof:lastmodified":1582331114,
     "wof:name":"Daqam ash Shar\u012bf",
     "wof:parent_id":1091922781,
     "wof:placetype":"locality",

--- a/data/890/427/725/890427725.geojson
+++ b/data/890/427/725/890427725.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051713,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0befaf095adbdc3a38972898c4ffc380",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890427725,
-    "wof:lastmodified":1566661337,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Ma\u2018qar",
     "wof:parent_id":1091920811,
     "wof:placetype":"locality",

--- a/data/890/427/815/890427815.geojson
+++ b/data/890/427/815/890427815.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051719,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c84384bdd908a3721cbe17193c93630",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":890427815,
-    "wof:lastmodified":1566661353,
+    "wof:lastmodified":1582331115,
     "wof:name":"\u1e28\u0101rat as S\u016bq al Jad\u012bd",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/427/939/890427939.geojson
+++ b/data/890/427/939/890427939.geojson
@@ -48,6 +48,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051728,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"316af2107a076c72ba78f859e680a0bc",
     "wof:hierarchy":[
         {
@@ -59,7 +62,7 @@
         }
     ],
     "wof:id":890427939,
-    "wof:lastmodified":1566661321,
+    "wof:lastmodified":1582331115,
     "wof:name":"An Nuqayl",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/428/043/890428043.geojson
+++ b/data/890/428/043/890428043.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051733,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c8fee8dbb208e1f67e620bd02ba5fdff",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890428043,
-    "wof:lastmodified":1566661195,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Mark\u0101bah",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/428/183/890428183.geojson
+++ b/data/890/428/183/890428183.geojson
@@ -45,6 +45,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051739,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3dd396bb7a8975b3a283a1500035b58",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890428183,
-    "wof:lastmodified":1566661203,
+    "wof:lastmodified":1582331113,
     "wof:name":"Az\u0327 Z\u0327ahirah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/428/335/890428335.geojson
+++ b/data/890/428/335/890428335.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051749,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a755de9e05d605bc39c27a115553021a",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890428335,
-    "wof:lastmodified":1566661189,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al \u2018Abl as Samarah",
     "wof:parent_id":1091919135,
     "wof:placetype":"locality",

--- a/data/890/428/357/890428357.geojson
+++ b/data/890/428/357/890428357.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051750,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60e78ecd1f3e4537e85835d39d21795c",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890428357,
-    "wof:lastmodified":1566661188,
+    "wof:lastmodified":1582331112,
     "wof:name":"As S\u0101dah",
     "wof:parent_id":1091919509,
     "wof:placetype":"locality",

--- a/data/890/428/423/890428423.geojson
+++ b/data/890/428/423/890428423.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051752,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a837496a76137dd2dc2c9b31e286e292",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890428423,
-    "wof:lastmodified":1566661179,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Qaryah",
     "wof:parent_id":1091919167,
     "wof:placetype":"locality",

--- a/data/890/428/477/890428477.geojson
+++ b/data/890/428/477/890428477.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051754,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c5fb83d0a2156a0e2b48f782a47327f",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890428477,
-    "wof:lastmodified":1566661177,
+    "wof:lastmodified":1582331112,
     "wof:name":"Al Qa\u1e29fah",
     "wof:parent_id":1091926417,
     "wof:placetype":"locality",

--- a/data/890/428/665/890428665.geojson
+++ b/data/890/428/665/890428665.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051763,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ba8c3de6f418fdc6027ebd4dc8c6b55",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890428665,
-    "wof:lastmodified":1566661199,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al \u1e28ala\u0163",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/429/647/890429647.geojson
+++ b/data/890/429/647/890429647.geojson
@@ -65,6 +65,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051824,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cda89f5189f4b9fd824be0e4836f4094",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890429647,
-    "wof:lastmodified":1566661243,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Kawlah",
     "wof:parent_id":1091923743,
     "wof:placetype":"locality",

--- a/data/890/429/871/890429871.geojson
+++ b/data/890/429/871/890429871.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051832,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"06cbefb9ddd2d05dca11fc65f7e91b5f",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890429871,
-    "wof:lastmodified":1566661243,
+    "wof:lastmodified":1582331113,
     "wof:name":"Ad Damigh",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/429/899/890429899.geojson
+++ b/data/890/429/899/890429899.geojson
@@ -49,6 +49,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051833,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b31647c876743cbf627aa78bbee9096f",
     "wof:hierarchy":[
         {
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":890429899,
-    "wof:lastmodified":1566661245,
+    "wof:lastmodified":1582331113,
     "wof:name":"Ad Darb",
     "wof:parent_id":1091923743,
     "wof:placetype":"locality",

--- a/data/890/429/941/890429941.geojson
+++ b/data/890/429/941/890429941.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051834,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0c05f08896baa2c8d543e25aff1547d",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890429941,
-    "wof:lastmodified":1566661241,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Qaz\u2018ah",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/430/097/890430097.geojson
+++ b/data/890/430/097/890430097.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051839,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11da538feeaf1685913542633c2a0759",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890430097,
-    "wof:lastmodified":1566660889,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Jallah",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/430/373/890430373.geojson
+++ b/data/890/430/373/890430373.geojson
@@ -418,6 +418,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469051850,
+    "wof:geom_alt":[
+        "unknown"
+    ],
     "wof:geomhash":"517a945a168d5622d0afd640ce3b6066",
     "wof:hierarchy":[
         {
@@ -429,7 +432,7 @@
         }
     ],
     "wof:id":890430373,
-    "wof:lastmodified":1566660893,
+    "wof:lastmodified":1582331109,
     "wof:name":"Aden",
     "wof:parent_id":1091918873,
     "wof:placetype":"locality",

--- a/data/890/435/577/890435577.geojson
+++ b/data/890/435/577/890435577.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052072,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c636209ce2bb1faa9b96a2ba5fbf854a",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890435577,
-    "wof:lastmodified":1566661420,
+    "wof:lastmodified":1582331116,
     "wof:name":"Al \u1e28amirah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/435/665/890435665.geojson
+++ b/data/890/435/665/890435665.geojson
@@ -68,6 +68,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052076,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0eaafee50ca6dbd7dea3662b96ae551a",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
         }
     ],
     "wof:id":890435665,
-    "wof:lastmodified":1566661418,
+    "wof:lastmodified":1582331116,
     "wof:name":"Al Q\u0101bil",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/435/827/890435827.geojson
+++ b/data/890/435/827/890435827.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052082,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0c7af10c18ed35135b7e41b65307ec72",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890435827,
-    "wof:lastmodified":1566661412,
+    "wof:lastmodified":1582331116,
     "wof:name":"Gh\u0101rib as Saw\u0101d",
     "wof:parent_id":1091922135,
     "wof:placetype":"locality",

--- a/data/890/436/089/890436089.geojson
+++ b/data/890/436/089/890436089.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052092,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5b4d71dda7dc8dcf70758bcb2fc2b8e4",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890436089,
-    "wof:lastmodified":1566660954,
+    "wof:lastmodified":1582331110,
     "wof:name":"Bayt al Ma\u015fli\u1e29ah",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/436/359/890436359.geojson
+++ b/data/890/436/359/890436359.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052108,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00e7a350fa136ae9299759faea784e3c",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890436359,
-    "wof:lastmodified":1566660952,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Maq\u2018\u012byah as Sufl\u00e1",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/437/355/890437355.geojson
+++ b/data/890/437/355/890437355.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052148,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"22a3df0e920b2d228e651a4b8a6a13c8",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890437355,
-    "wof:lastmodified":1566660895,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Ma\u1e29d\u0101dah",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/437/493/890437493.geojson
+++ b/data/890/437/493/890437493.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052153,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c8a2d5cdfef53606a5f73d0fcda04c5",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890437493,
-    "wof:lastmodified":1566660904,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Kab\u016brah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/437/529/890437529.geojson
+++ b/data/890/437/529/890437529.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052155,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c2a010c14754ad0922011a0a03ab98c5",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890437529,
-    "wof:lastmodified":1566660899,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Mi\u2018zab",
     "wof:parent_id":1091925425,
     "wof:placetype":"locality",

--- a/data/890/437/993/890437993.geojson
+++ b/data/890/437/993/890437993.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052175,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44b5680c80b99e4ae48f2e98883d3959",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890437993,
-    "wof:lastmodified":1566660901,
+    "wof:lastmodified":1582331110,
     "wof:name":"As Saw\u0101r",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/438/953/890438953.geojson
+++ b/data/890/438/953/890438953.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052216,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2441ba575f4bc3db36ae5f3a6adf11b2",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890438953,
-    "wof:lastmodified":1566660959,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Ma\u1e29all",
     "wof:parent_id":1091925497,
     "wof:placetype":"locality",

--- a/data/890/438/979/890438979.geojson
+++ b/data/890/438/979/890438979.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052217,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"263c4b1d7d80a5f05dec059491ce6ad8",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890438979,
-    "wof:lastmodified":1566660962,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Ma\u2018\u0101tiq",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/439/037/890439037.geojson
+++ b/data/890/439/037/890439037.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052219,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ef06b954a23e564fbef86e9d3f2c68d5",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890439037,
-    "wof:lastmodified":1566660858,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Ma\u1e29a\u0163\u0163ah",
     "wof:parent_id":1091923483,
     "wof:placetype":"locality",

--- a/data/890/439/065/890439065.geojson
+++ b/data/890/439/065/890439065.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052220,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3dbdfa062a13bfdc8b9dea0fc80e8b38",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890439065,
-    "wof:lastmodified":1566660854,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Muj\u0101r\u012bn",
     "wof:parent_id":1091925497,
     "wof:placetype":"locality",

--- a/data/890/439/107/890439107.geojson
+++ b/data/890/439/107/890439107.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052221,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b985f8347e62f87695aadc8bd4e7489",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890439107,
-    "wof:lastmodified":1566660866,
+    "wof:lastmodified":1582331109,
     "wof:name":"Bayt al \u1e28ay\u0101f",
     "wof:parent_id":1091925497,
     "wof:placetype":"locality",

--- a/data/890/439/125/890439125.geojson
+++ b/data/890/439/125/890439125.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052222,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"faa7344cae64717a2505fcf472dd6f03",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890439125,
-    "wof:lastmodified":1566660883,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Lujj",
     "wof:parent_id":1091923483,
     "wof:placetype":"locality",

--- a/data/890/439/189/890439189.geojson
+++ b/data/890/439/189/890439189.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052225,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"857dc7d7c7084d6907a81b8c512d9edd",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890439189,
-    "wof:lastmodified":1566660860,
+    "wof:lastmodified":1582331109,
     "wof:name":"Maq\u0101m Ab\u016b Naw\u0101s",
     "wof:parent_id":1091920811,
     "wof:placetype":"locality",

--- a/data/890/439/209/890439209.geojson
+++ b/data/890/439/209/890439209.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052226,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f309810e7e1901992d362db0bfa5b857",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890439209,
-    "wof:lastmodified":1566660876,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al Hajar",
     "wof:parent_id":1091925025,
     "wof:placetype":"locality",

--- a/data/890/439/215/890439215.geojson
+++ b/data/890/439/215/890439215.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052226,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3bbe34b46ed563ba0fcc9c18b1f90735",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890439215,
-    "wof:lastmodified":1566660871,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al \u1e28\u0101\u2019i\u0163",
     "wof:parent_id":1091921649,
     "wof:placetype":"locality",

--- a/data/890/439/335/890439335.geojson
+++ b/data/890/439/335/890439335.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052231,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c91fffcba0360c46b676ab8c2c4c4786",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890439335,
-    "wof:lastmodified":1566660866,
+    "wof:lastmodified":1582331109,
     "wof:name":"Ad D\u0101rah",
     "wof:parent_id":1091921861,
     "wof:placetype":"locality",

--- a/data/890/439/395/890439395.geojson
+++ b/data/890/439/395/890439395.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052234,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74cae6d7985ca14e15e7e49c2efbab02",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890439395,
-    "wof:lastmodified":1566660865,
+    "wof:lastmodified":1582331109,
     "wof:name":"Darb R\u0101zi\u1e29",
     "wof:parent_id":1091921861,
     "wof:placetype":"locality",

--- a/data/890/439/695/890439695.geojson
+++ b/data/890/439/695/890439695.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052246,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5e5cd490fb1bcae271e8922477db5d6c",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890439695,
-    "wof:lastmodified":1566660858,
+    "wof:lastmodified":1582331109,
     "wof:name":"Al \u1e28amr\u0101\u2019",
     "wof:parent_id":1091926417,
     "wof:placetype":"locality",

--- a/data/890/440/427/890440427.geojson
+++ b/data/890/440/427/890440427.geojson
@@ -45,6 +45,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052275,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fdad557c80f94b1259ffa3b66c7fb1ac",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890440427,
-    "wof:lastmodified":1566660451,
+    "wof:lastmodified":1582331103,
     "wof:name":"Al Yaman",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/442/625/890442625.geojson
+++ b/data/890/442/625/890442625.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052369,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2db7f549912c05178156f772ed78f3b8",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890442625,
-    "wof:lastmodified":1566661374,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Qu\u2018\u0101d",
     "wof:parent_id":1091921649,
     "wof:placetype":"locality",

--- a/data/890/442/681/890442681.geojson
+++ b/data/890/442/681/890442681.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052372,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b21033ddcc146a7ad420a02658917e6",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890442681,
-    "wof:lastmodified":1566661369,
+    "wof:lastmodified":1582331115,
     "wof:name":"\u0100l Ma\u1e29f\u016bz\u0327",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/442/775/890442775.geojson
+++ b/data/890/442/775/890442775.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052378,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6754ec8b36fc9d50f8224a5151170a1",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890442775,
-    "wof:lastmodified":1566661377,
+    "wof:lastmodified":1582331115,
     "wof:name":"Adh Dhir\u0101\u2018",
     "wof:parent_id":1091925365,
     "wof:placetype":"locality",

--- a/data/890/442/793/890442793.geojson
+++ b/data/890/442/793/890442793.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052379,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c88f437e6c09943bfc4208cfc1fc5e30",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890442793,
-    "wof:lastmodified":1566661373,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Qaz\u2018\u012b",
     "wof:parent_id":1091921861,
     "wof:placetype":"locality",

--- a/data/890/443/761/890443761.geojson
+++ b/data/890/443/761/890443761.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052437,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23d8871cde835babd23208b9777805b4",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890443761,
-    "wof:lastmodified":1566661235,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Jumaymah",
     "wof:parent_id":1091925497,
     "wof:placetype":"locality",

--- a/data/890/444/577/890444577.geojson
+++ b/data/890/444/577/890444577.geojson
@@ -63,6 +63,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052474,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8229acd69673d7279b3d72ec5f2ac39f",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890444577,
-    "wof:lastmodified":1566661234,
+    "wof:lastmodified":1582331113,
     "wof:name":"Al Kawlah",
     "wof:parent_id":1091921523,
     "wof:placetype":"locality",

--- a/data/890/444/617/890444617.geojson
+++ b/data/890/444/617/890444617.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052475,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a9bada2a8a465e065b7f94659f625db7",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890444617,
-    "wof:lastmodified":1566661227,
+    "wof:lastmodified":1582331113,
     "wof:name":"As Sulayl",
     "wof:parent_id":1091925759,
     "wof:placetype":"locality",

--- a/data/890/445/907/890445907.geojson
+++ b/data/890/445/907/890445907.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052527,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e19d1918b87dd3d988d443d859a2bbf9",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890445907,
-    "wof:lastmodified":1566661378,
+    "wof:lastmodified":1582331115,
     "wof:name":"Makhsh\u016bsh",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/445/917/890445917.geojson
+++ b/data/890/445/917/890445917.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052527,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e96d134c1def799bc5b5b003527c9089",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890445917,
-    "wof:lastmodified":1566661398,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al \u2018Ashshah",
     "wof:parent_id":1091923743,
     "wof:placetype":"locality",

--- a/data/890/445/955/890445955.geojson
+++ b/data/890/445/955/890445955.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052529,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e7c9233051a93991aa0b0295ee318b9",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890445955,
-    "wof:lastmodified":1566661381,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Qayyam",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/446/035/890446035.geojson
+++ b/data/890/446/035/890446035.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052532,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f3cd8546b703357f06b497bb0b1b354",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890446035,
-    "wof:lastmodified":1566660757,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Khir\u0101\u2019ib",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/446/057/890446057.geojson
+++ b/data/890/446/057/890446057.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052534,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e194437326dc3408dc39e135ad7210f",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446057,
-    "wof:lastmodified":1566660758,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al \u1e28adabah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/097/890446097.geojson
+++ b/data/890/446/097/890446097.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052535,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d2188bdefb22fadf4ba69ec6fe3f117b",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890446097,
-    "wof:lastmodified":1566660737,
+    "wof:lastmodified":1582331107,
     "wof:name":"A\u0163 \u0162arf",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/115/890446115.geojson
+++ b/data/890/446/115/890446115.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052539,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ed192b75ee2cb6aa22e6ceabb4233f21",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890446115,
-    "wof:lastmodified":1566660763,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Kawlah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/139/890446139.geojson
+++ b/data/890/446/139/890446139.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052540,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0e2cfb48ca3e3e8ac77c44967f6efb72",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446139,
-    "wof:lastmodified":1566660748,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ath Thaw\u0101hir",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/147/890446147.geojson
+++ b/data/890/446/147/890446147.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052540,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd5b934066e73a6279984cc6127fc62d",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446147,
-    "wof:lastmodified":1566660767,
+    "wof:lastmodified":1582331108,
     "wof:name":"As Sahilah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/207/890446207.geojson
+++ b/data/890/446/207/890446207.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052542,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4c3d3075728af55ce395632221a257cd",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446207,
-    "wof:lastmodified":1566660757,
+    "wof:lastmodified":1582331108,
     "wof:name":"Ar Raw\u1e29\u0101\u2019",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/446/273/890446273.geojson
+++ b/data/890/446/273/890446273.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052545,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7527a0024961b5513b3de86272654c24",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890446273,
-    "wof:lastmodified":1566660728,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Aqs\u0101m",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/446/305/890446305.geojson
+++ b/data/890/446/305/890446305.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052546,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"82a662f08119ab51806257e53dd335f0",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890446305,
-    "wof:lastmodified":1566660749,
+    "wof:lastmodified":1582331107,
     "wof:name":"Bayt Mu\u1e29ammad \u2018Al\u012b",
     "wof:parent_id":1091923953,
     "wof:placetype":"locality",

--- a/data/890/446/333/890446333.geojson
+++ b/data/890/446/333/890446333.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052547,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2149538ec62fd50051838f4aff950031",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890446333,
-    "wof:lastmodified":1566660748,
+    "wof:lastmodified":1582331107,
     "wof:name":"Bayt al Q\u0101\u1e11\u012b",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/446/359/890446359.geojson
+++ b/data/890/446/359/890446359.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052549,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e5d09c0a3c072dd3d9a369941acdc3af",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890446359,
-    "wof:lastmodified":1566660745,
+    "wof:lastmodified":1582331107,
     "wof:name":"Bayt al Maghribah",
     "wof:parent_id":1091923449,
     "wof:placetype":"locality",

--- a/data/890/446/663/890446663.geojson
+++ b/data/890/446/663/890446663.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052561,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d539187f95dfa712375c28215fc681e8",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446663,
-    "wof:lastmodified":1566660757,
+    "wof:lastmodified":1582331107,
     "wof:name":"An Nayd",
     "wof:parent_id":1091925525,
     "wof:placetype":"locality",

--- a/data/890/446/677/890446677.geojson
+++ b/data/890/446/677/890446677.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052561,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fb068d3d66e5e4da88632504657df5ce",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890446677,
-    "wof:lastmodified":1566660755,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ar Raq\u2018ah",
     "wof:parent_id":1091925525,
     "wof:placetype":"locality",

--- a/data/890/446/823/890446823.geojson
+++ b/data/890/446/823/890446823.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052568,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"891cffc694e02117cab3207ee519f297",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890446823,
-    "wof:lastmodified":1566660751,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al \u1e28arrah",
     "wof:parent_id":1091920749,
     "wof:placetype":"locality",

--- a/data/890/446/845/890446845.geojson
+++ b/data/890/446/845/890446845.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052569,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"799bb7b21af3f155e91b01e1b5f57475",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890446845,
-    "wof:lastmodified":1566660728,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Ma\u1e29jarah",
     "wof:parent_id":1091920775,
     "wof:placetype":"locality",

--- a/data/890/446/899/890446899.geojson
+++ b/data/890/446/899/890446899.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052571,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"086e5bfa98ccf01051f533303494adb0",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890446899,
-    "wof:lastmodified":1566660760,
+    "wof:lastmodified":1582331108,
     "wof:name":"Al Maq\u015firah",
     "wof:parent_id":1091920775,
     "wof:placetype":"locality",

--- a/data/890/447/237/890447237.geojson
+++ b/data/890/447/237/890447237.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052584,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5de56158bb86723e4720d3481bea69d3",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447237,
-    "wof:lastmodified":1566660496,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Jillah",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/447/261/890447261.geojson
+++ b/data/890/447/261/890447261.geojson
@@ -72,6 +72,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052585,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d18b980d2b15af6db0904447f4ca040b",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890447261,
-    "wof:lastmodified":1566660467,
+    "wof:lastmodified":1582331104,
     "wof:name":"\u0100l Mub\u0101rak",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/447/385/890447385.geojson
+++ b/data/890/447/385/890447385.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052590,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"418e7aacb771f18ffe2a5174b4763fcf",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890447385,
-    "wof:lastmodified":1566660476,
+    "wof:lastmodified":1582331104,
     "wof:name":"Qarn al Bad\u012b\u2018",
     "wof:parent_id":1091924239,
     "wof:placetype":"locality",

--- a/data/890/447/443/890447443.geojson
+++ b/data/890/447/443/890447443.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052592,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7dd3a0994afbbabef47931ddb411cf1d",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890447443,
-    "wof:lastmodified":1566660487,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Khawrimah",
     "wof:parent_id":1091924239,
     "wof:placetype":"locality",

--- a/data/890/447/487/890447487.geojson
+++ b/data/890/447/487/890447487.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052594,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9f064cf357242b67d6fa68ef50276dd",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447487,
-    "wof:lastmodified":1566660489,
+    "wof:lastmodified":1582331104,
     "wof:name":"A\u0163 \u0162aw\u012blah",
     "wof:parent_id":1091924239,
     "wof:placetype":"locality",

--- a/data/890/447/515/890447515.geojson
+++ b/data/890/447/515/890447515.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052595,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"44cacbc41f02eb608357b4a564b78748",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447515,
-    "wof:lastmodified":1566660505,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Khadr\u0101\u2019",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/447/549/890447549.geojson
+++ b/data/890/447/549/890447549.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052596,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"16a062a97f3bb30936a03c5a531ab849",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447549,
-    "wof:lastmodified":1566660498,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al \u2018Aqab\u012b",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/447/637/890447637.geojson
+++ b/data/890/447/637/890447637.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052600,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"acc0e6975b7dbdd2a045fa355893b428",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890447637,
-    "wof:lastmodified":1566660493,
+    "wof:lastmodified":1582331104,
     "wof:name":"Ar Ruknah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/447/833/890447833.geojson
+++ b/data/890/447/833/890447833.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052607,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd724da446b24844f457fdf07725a668",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447833,
-    "wof:lastmodified":1566660471,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Qatib",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/447/869/890447869.geojson
+++ b/data/890/447/869/890447869.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052608,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4afeb4bf8ee6f31e40e292d0cdfc8f42",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890447869,
-    "wof:lastmodified":1566660470,
+    "wof:lastmodified":1582331104,
     "wof:name":"Dhir\u0101\u2018 a\u015f \u015eiy\u0101b",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/447/925/890447925.geojson
+++ b/data/890/447/925/890447925.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052610,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c0e9d7dfd13a9f638e40c1fbcad75b8f",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890447925,
-    "wof:lastmodified":1566660478,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Marw\u00e1",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/448/015/890448015.geojson
+++ b/data/890/448/015/890448015.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c32e86f7265185f0220d6c4f5c63b79e",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890448015,
-    "wof:lastmodified":1566660677,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al \u2018Amsh",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/448/017/890448017.geojson
+++ b/data/890/448/017/890448017.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"487eb845da1d4469cf610ae8a99addfe",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890448017,
-    "wof:lastmodified":1566660707,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Mi\u0163r\u0101sh",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/448/023/890448023.geojson
+++ b/data/890/448/023/890448023.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052616,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ab7ea05171393d7ae7fab24fc8df9109",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890448023,
-    "wof:lastmodified":1566660677,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Mawdinah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/448/069/890448069.geojson
+++ b/data/890/448/069/890448069.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052618,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e94c48380e81a8483c937d001e00191c",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890448069,
-    "wof:lastmodified":1566660713,
+    "wof:lastmodified":1582331107,
     "wof:name":"An Naq\u2018ah",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/448/323/890448323.geojson
+++ b/data/890/448/323/890448323.geojson
@@ -60,6 +60,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a99baf5a234fbc0c4cb13b65064a32f3",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":890448323,
-    "wof:lastmodified":1566660691,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Jawwah as Sawd\u0101\u2019",
     "wof:parent_id":1091920575,
     "wof:placetype":"locality",

--- a/data/890/448/331/890448331.geojson
+++ b/data/890/448/331/890448331.geojson
@@ -56,6 +56,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052627,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca0d40e53cb110012b776913e8e562d5",
     "wof:hierarchy":[
         {
@@ -67,7 +70,7 @@
         }
     ],
     "wof:id":890448331,
-    "wof:lastmodified":1566660672,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ba\u1e29rah",
     "wof:parent_id":1091920575,
     "wof:placetype":"locality",

--- a/data/890/448/427/890448427.geojson
+++ b/data/890/448/427/890448427.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052631,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"336d3d956a6b07290803b6b1f3d2790e",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890448427,
-    "wof:lastmodified":1566660707,
+    "wof:lastmodified":1582331107,
     "wof:name":"Al Badi\u1e29",
     "wof:parent_id":1091923769,
     "wof:placetype":"locality",

--- a/data/890/448/851/890448851.geojson
+++ b/data/890/448/851/890448851.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052648,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2b8c3ed0313541fcad226fddcd4907bd",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890448851,
-    "wof:lastmodified":1566660686,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ash Shirm\u0101t",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/448/857/890448857.geojson
+++ b/data/890/448/857/890448857.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052649,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"458a5d19debeac93bf64cf9906a59be0",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890448857,
-    "wof:lastmodified":1566660684,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ath Th\u016b\u2018ah",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/448/961/890448961.geojson
+++ b/data/890/448/961/890448961.geojson
@@ -180,6 +180,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052655,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9e6eeaba9caa5946eb9f704badf33e4",
     "wof:hierarchy":[
         {
@@ -191,7 +194,7 @@
         }
     ],
     "wof:id":890448961,
-    "wof:lastmodified":1566660696,
+    "wof:lastmodified":1582331107,
     "wof:name":"Ash Sh\u0101\u0163i\u2019",
     "wof:parent_id":1091923483,
     "wof:placetype":"locality",

--- a/data/890/448/979/890448979.geojson
+++ b/data/890/448/979/890448979.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052655,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb58b2c60f05dad8098bee9c9c620f4a",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890448979,
-    "wof:lastmodified":1566660690,
+    "wof:lastmodified":1582331107,
     "wof:name":"Gh\u0101rib ash Shar\u012bf",
     "wof:parent_id":1091921649,
     "wof:placetype":"locality",

--- a/data/890/449/025/890449025.geojson
+++ b/data/890/449/025/890449025.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052663,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ab2fe41fab73b78a8ea0ee9aad705f1",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890449025,
-    "wof:lastmodified":1566660514,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Bayt al A\u2018l\u00e1",
     "wof:parent_id":1091922105,
     "wof:placetype":"locality",

--- a/data/890/449/145/890449145.geojson
+++ b/data/890/449/145/890449145.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052671,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"13ce6cb58a9d38b0865e9fe12d8d0c94",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890449145,
-    "wof:lastmodified":1566660520,
+    "wof:lastmodified":1582331104,
     "wof:name":"Ar Ranfah",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/449/159/890449159.geojson
+++ b/data/890/449/159/890449159.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052672,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbd57c96ee1a673cd2ecae21c1a4293b",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890449159,
-    "wof:lastmodified":1566660507,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Qullah",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/449/211/890449211.geojson
+++ b/data/890/449/211/890449211.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052676,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"86b9c184bff19e83d45e9a78ae9468b4",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890449211,
-    "wof:lastmodified":1566660511,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Judaydah",
     "wof:parent_id":1091919509,
     "wof:placetype":"locality",

--- a/data/890/449/213/890449213.geojson
+++ b/data/890/449/213/890449213.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052676,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6b7f382c71c76dcf94e86ff075bc5f9d",
     "wof:hierarchy":[
         {
@@ -69,7 +72,7 @@
         }
     ],
     "wof:id":890449213,
-    "wof:lastmodified":1566660533,
+    "wof:lastmodified":1582331105,
     "wof:name":"\u0100l \u2018Abd All\u0101h",
     "wof:parent_id":1091919055,
     "wof:placetype":"locality",

--- a/data/890/449/225/890449225.geojson
+++ b/data/890/449/225/890449225.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052676,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f57125a7a1badaef3722230a97a9829",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890449225,
-    "wof:lastmodified":1566660532,
+    "wof:lastmodified":1582331105,
     "wof:name":"Ad Daraj",
     "wof:parent_id":1091919055,
     "wof:placetype":"locality",

--- a/data/890/449/267/890449267.geojson
+++ b/data/890/449/267/890449267.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052680,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"277635d9cae276b31a61b2f769bcc5ed",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890449267,
-    "wof:lastmodified":1566660517,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Munqa\u0163i\u2018",
     "wof:parent_id":1091919203,
     "wof:placetype":"locality",

--- a/data/890/449/417/890449417.geojson
+++ b/data/890/449/417/890449417.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052690,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aeaa9bc52e98da1fed7693f6ebbcb784",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890449417,
-    "wof:lastmodified":1566660530,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al \u2018Aqqah",
     "wof:parent_id":1091926707,
     "wof:placetype":"locality",

--- a/data/890/449/419/890449419.geojson
+++ b/data/890/449/419/890449419.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052690,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"561305a8a18c94daca3c334773065d23",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890449419,
-    "wof:lastmodified":1566660528,
+    "wof:lastmodified":1582331105,
     "wof:name":"Al J\u0101hil\u012b",
     "wof:parent_id":1091926707,
     "wof:placetype":"locality",

--- a/data/890/449/455/890449455.geojson
+++ b/data/890/449/455/890449455.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052692,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9865da416553ceb37ef6c6eda5522854",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890449455,
-    "wof:lastmodified":1566660517,
+    "wof:lastmodified":1582331104,
     "wof:name":"Ma\u1e29\u0101l\u012bb ad D\u0101khil",
     "wof:parent_id":1091926463,
     "wof:placetype":"locality",

--- a/data/890/449/643/890449643.geojson
+++ b/data/890/449/643/890449643.geojson
@@ -62,6 +62,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052701,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f6fbb322c57f7c271fe85f3fdb5b3175",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
         }
     ],
     "wof:id":890449643,
-    "wof:lastmodified":1566660512,
+    "wof:lastmodified":1582331104,
     "wof:name":"W\u0101d\u012b H\u0101yah",
     "wof:parent_id":1091926417,
     "wof:placetype":"locality",

--- a/data/890/449/979/890449979.geojson
+++ b/data/890/449/979/890449979.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052719,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f0832b888c1ac8eaa608334ce48a9a86",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890449979,
-    "wof:lastmodified":1566660520,
+    "wof:lastmodified":1582331104,
     "wof:name":"Al Khanaq",
     "wof:parent_id":1091925427,
     "wof:placetype":"locality",

--- a/data/890/451/833/890451833.geojson
+++ b/data/890/451/833/890451833.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052795,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e4c6ab757b7682ab66b566ab41705bc",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890451833,
-    "wof:lastmodified":1566661403,
+    "wof:lastmodified":1582331115,
     "wof:name":"Kawlat a\u015f \u015eiy\u0101d",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/451/851/890451851.geojson
+++ b/data/890/451/851/890451851.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052796,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"232131a6b50810e5858178c24f7b1f3b",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":890451851,
-    "wof:lastmodified":1566661402,
+    "wof:lastmodified":1582331115,
     "wof:name":"Al Ghad\u012br",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/452/327/890452327.geojson
+++ b/data/890/452/327/890452327.geojson
@@ -51,6 +51,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052812,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c1f46f2f646e93c2a8a309ccba2e3317",
     "wof:hierarchy":[
         {
@@ -62,7 +65,7 @@
         }
     ],
     "wof:id":890452327,
-    "wof:lastmodified":1566660920,
+    "wof:lastmodified":1582331110,
     "wof:name":"Sa\u2018\u012bdah",
     "wof:parent_id":1091919055,
     "wof:placetype":"locality",

--- a/data/890/452/333/890452333.geojson
+++ b/data/890/452/333/890452333.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052813,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e7426df45c43104e14a32056dcb5539",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890452333,
-    "wof:lastmodified":1566660917,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al \u2018Ajmah",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/452/349/890452349.geojson
+++ b/data/890/452/349/890452349.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052813,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"07beb4f14bd7c2f597797c2eaecdc566",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890452349,
-    "wof:lastmodified":1566660915,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al W\u0101\u1e11i\u1e29",
     "wof:parent_id":1091925277,
     "wof:placetype":"locality",

--- a/data/890/453/615/890453615.geojson
+++ b/data/890/453/615/890453615.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052861,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ff0e010e4a30a5ff8ec3239dc374e9a",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890453615,
-    "wof:lastmodified":1566661026,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Qa\u0163\u2018ah",
     "wof:parent_id":1091925525,
     "wof:placetype":"locality",

--- a/data/890/453/685/890453685.geojson
+++ b/data/890/453/685/890453685.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052868,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9d800d2152d81dfa8711c292e1877e8b",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890453685,
-    "wof:lastmodified":1566661024,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al \u1e28\u0101jab",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/453/697/890453697.geojson
+++ b/data/890/453/697/890453697.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052869,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"00109263e94d60c8b8732f891c2d432b",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890453697,
-    "wof:lastmodified":1566661027,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Miqsh\u0101b",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/453/785/890453785.geojson
+++ b/data/890/453/785/890453785.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052873,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83a9599511c129690ca8ef179c4bff4c",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890453785,
-    "wof:lastmodified":1566661017,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Bi\u0163\u0101\u1e29\u012b",
     "wof:parent_id":1091925417,
     "wof:placetype":"locality",

--- a/data/890/453/827/890453827.geojson
+++ b/data/890/453/827/890453827.geojson
@@ -59,6 +59,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052875,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b0304c31b9393cb9ae64dc8c473cf2e6",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890453827,
-    "wof:lastmodified":1566661007,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Qurayn",
     "wof:parent_id":1091926707,
     "wof:placetype":"locality",

--- a/data/890/453/933/890453933.geojson
+++ b/data/890/453/933/890453933.geojson
@@ -53,6 +53,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052878,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"58ba7743ce00e32397b7010a8c58254d",
     "wof:hierarchy":[
         {
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890453933,
-    "wof:lastmodified":1566661023,
+    "wof:lastmodified":1582331111,
     "wof:name":"Ghayl al Qushayb",
     "wof:parent_id":1091922105,
     "wof:placetype":"locality",

--- a/data/890/454/373/890454373.geojson
+++ b/data/890/454/373/890454373.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052897,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"14f71148921852cd00e5ba2536919c28",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890454373,
-    "wof:lastmodified":1566661001,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al \u2018Aqqam",
     "wof:parent_id":1091923925,
     "wof:placetype":"locality",

--- a/data/890/454/441/890454441.geojson
+++ b/data/890/454/441/890454441.geojson
@@ -46,6 +46,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052900,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4124f9b7a2915b72db87e3fe7c12835f",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890454441,
-    "wof:lastmodified":1534379831,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Miqsh\u0101b",
     "wof:parent_id":1091924151,
     "wof:placetype":"locality",

--- a/data/890/454/683/890454683.geojson
+++ b/data/890/454/683/890454683.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052910,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6f51045bdfd70d61a87986a260b88deb",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890454683,
-    "wof:lastmodified":1566660994,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Khal\u012bf",
     "wof:parent_id":1091920749,
     "wof:placetype":"locality",

--- a/data/890/454/833/890454833.geojson
+++ b/data/890/454/833/890454833.geojson
@@ -77,6 +77,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052916,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6e85da5d4b4570898e673d8421becf4a",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":890454833,
-    "wof:lastmodified":1566660980,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Mar\u0101w\u012b",
     "wof:parent_id":1091925457,
     "wof:placetype":"locality",

--- a/data/890/454/881/890454881.geojson
+++ b/data/890/454/881/890454881.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052918,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d88ea5e251eaa4541a079bbd4de8e482",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890454881,
-    "wof:lastmodified":1566660976,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Baq\u2018ah",
     "wof:parent_id":1091925573,
     "wof:placetype":"locality",

--- a/data/890/454/947/890454947.geojson
+++ b/data/890/454/947/890454947.geojson
@@ -75,6 +75,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052921,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"75700167502b1f3bd6c560009123c1d8",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":890454947,
-    "wof:lastmodified":1566660984,
+    "wof:lastmodified":1582331111,
     "wof:name":"Al Maghrabah",
     "wof:parent_id":1091921861,
     "wof:placetype":"locality",

--- a/data/890/454/963/890454963.geojson
+++ b/data/890/454/963/890454963.geojson
@@ -45,6 +45,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052922,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"533e937466f2808fd0421d7ff0867bb6",
     "wof:hierarchy":[
         {
@@ -57,7 +60,7 @@
         }
     ],
     "wof:id":890454963,
-    "wof:lastmodified":1566660972,
+    "wof:lastmodified":1582331110,
     "wof:name":"A\u1e11 \u1e10al\u2018ah",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/455/009/890455009.geojson
+++ b/data/890/455/009/890455009.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052929,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"60d677192390b80ee6e2c855a51678d1",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890455009,
-    "wof:lastmodified":1566660929,
+    "wof:lastmodified":1582331110,
     "wof:name":"Ash Shar\u012b",
     "wof:parent_id":1091919135,
     "wof:placetype":"locality",

--- a/data/890/455/051/890455051.geojson
+++ b/data/890/455/051/890455051.geojson
@@ -57,6 +57,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052931,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6ad5177f389f95441f0a1b4ce4f78fe8",
     "wof:hierarchy":[
         {
@@ -68,7 +71,7 @@
         }
     ],
     "wof:id":890455051,
-    "wof:lastmodified":1566660940,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Midy\u0101r",
     "wof:parent_id":1091925079,
     "wof:placetype":"locality",

--- a/data/890/455/139/890455139.geojson
+++ b/data/890/455/139/890455139.geojson
@@ -54,6 +54,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052935,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a3e7475b6f184190091f23c0b654b4b",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":890455139,
-    "wof:lastmodified":1566660934,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al \u1e28ujayr",
     "wof:parent_id":1091926463,
     "wof:placetype":"locality",

--- a/data/890/455/461/890455461.geojson
+++ b/data/890/455/461/890455461.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052953,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fc99502cacc274b3346dc04474563e78",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890455461,
-    "wof:lastmodified":1566660939,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Mikhy\u0101m",
     "wof:parent_id":1091924327,
     "wof:placetype":"locality",

--- a/data/890/455/505/890455505.geojson
+++ b/data/890/455/505/890455505.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052955,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"306471c83cb2dd113e0a746234caad25",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890455505,
-    "wof:lastmodified":1566660924,
+    "wof:lastmodified":1582331110,
     "wof:name":"Adh Dhir\u0101\u2018",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/455/521/890455521.geojson
+++ b/data/890/455/521/890455521.geojson
@@ -50,6 +50,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052955,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af7a22b5c12da82e6c2d9a9f51ec8b2f",
     "wof:hierarchy":[
         {
@@ -61,7 +64,7 @@
         }
     ],
     "wof:id":890455521,
-    "wof:lastmodified":1566660931,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al \u2018Ariq",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",

--- a/data/890/455/541/890455541.geojson
+++ b/data/890/455/541/890455541.geojson
@@ -47,6 +47,9 @@
     },
     "wof:country":"YE",
     "wof:created":1469052956,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0b5d4410080c3eb27122080caaaad3e5",
     "wof:hierarchy":[
         {
@@ -58,7 +61,7 @@
         }
     ],
     "wof:id":890455541,
-    "wof:lastmodified":1566660942,
+    "wof:lastmodified":1582331110,
     "wof:name":"Al Marwah",
     "wof:parent_id":1091924059,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.