### PR TITLE
ye concordances, placetype local, and more

### DIFF
--- a/data/109/191/842/9/1091918429.geojson
+++ b/data/109/191/842/9/1091918429.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.307087,
-    "geom:area_square_m":3689612904.329064,
+    "geom:area_square_m":3689613371.953326,
     "geom:bbox":"46.324407,13.404555,47.186712,13.967337",
     "geom:latitude":13.670506,
     "geom:longitude":46.778099,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AB.AH",
         "wd:id":"Q4117549"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892931,
-    "wof:geomhash":"6ef5adbf29a2c5ef08062b4d2934da72",
+    "wof:geomhash":"98e2741426893e1cce63e3217171b191",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918429,
-    "wof:lastmodified":1690925026,
+    "wof:lastmodified":1695886514,
     "wof:name":"Ahwar",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/845/5/1091918455.geojson
+++ b/data/109/191/845/5/1091918455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.231253,
-    "geom:area_square_m":2774681706.378606,
+    "geom:area_square_m":2774681795.671311,
     "geom:bbox":"46.352876,13.733315,47.161426,14.206604",
     "geom:latitude":13.98901,
     "geom:longitude":46.711861,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AB.MA",
         "wd:id":"Q4117574"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892933,
-    "wof:geomhash":"781c2610f40534395c205eed54834288",
+    "wof:geomhash":"0a2b573df3574e2d40429d1d87c19e83",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918455,
-    "wof:lastmodified":1690925025,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Mahfad",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/848/7/1091918487.geojson
+++ b/data/109/191/848/7/1091918487.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053792,
-    "geom:area_square_m":646168979.478835,
+    "geom:area_square_m":646168886.580647,
     "geom:bbox":"45.85122,13.58819,46.177757,13.839223",
     "geom:latitude":13.719526,
     "geom:longitude":46.020532,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AB.WA",
         "wd:id":"Q4117454"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892934,
-    "wof:geomhash":"657b0abf2ed4c7b29ec8420ec3a14d73",
+    "wof:geomhash":"0941c90a1d8e94c343e8a6146ab0e776",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091918487,
-    "wof:lastmodified":1690925036,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Wade'a",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/851/9/1091918519.geojson
+++ b/data/109/191/851/9/1091918519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063866,
-    "geom:area_square_m":765660960.615668,
+    "geom:area_square_m":765660877.321299,
     "geom:bbox":"46.006822,14.015644,46.34054,14.31929",
     "geom:latitude":14.177323,
     "geom:longitude":46.184348,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AB.JA",
         "wd:id":"Q4117520"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892935,
-    "wof:geomhash":"d75b7bac097a09e906aa60616810a34a",
+    "wof:geomhash":"7746b9854879154aa798caf7447801c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918519,
-    "wof:lastmodified":1690925028,
+    "wof:lastmodified":1695886514,
     "wof:name":"Jayshan",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/855/3/1091918553.geojson
+++ b/data/109/191/855/3/1091918553.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.327006,
-    "geom:area_square_m":3933458910.758192,
+    "geom:area_square_m":3933458257.166988,
     "geom:bbox":"45.067702,12.935917,46.397109,13.738088",
     "geom:latitude":13.395888,
     "geom:longitude":45.693429,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AB.KH",
         "wd:id":"Q4117538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892936,
-    "wof:geomhash":"118fef7f2f45aea549d4e25c47eb8417",
+    "wof:geomhash":"975825fc70bf430572cb2e7b4bd29694",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091918553,
-    "wof:lastmodified":1690925039,
+    "wof:lastmodified":1695886516,
     "wof:name":"Khanfir",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/856/9/1091918569.geojson
+++ b/data/109/191/856/9/1091918569.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.177022,
-    "geom:area_square_m":2125832979.654704,
+    "geom:area_square_m":2125832993.955472,
     "geom:bbox":"45.453906,13.48779,46.147439,14.127644",
     "geom:latitude":13.787466,
     "geom:longitude":45.787621,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AB.LA",
         "wd:id":"Q1164303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892937,
-    "wof:geomhash":"10f9b503433e996cb14d58ff3abf8977",
+    "wof:geomhash":"6c656f56a1f7bb196221decb611ff009",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091918569,
-    "wof:lastmodified":1690925028,
+    "wof:lastmodified":1695886515,
     "wof:name":"Lawdar",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/859/3/1091918593.geojson
+++ b/data/109/191/859/3/1091918593.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09193,
-    "geom:area_square_m":1103416021.668887,
+    "geom:area_square_m":1103415892.979666,
     "geom:bbox":"46.002894,13.7304,46.430175,14.084738",
     "geom:latitude":13.904847,
     "geom:longitude":46.228348,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AB.MU",
         "wd:id":"Q4117556"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892938,
-    "wof:geomhash":"9312041e83cd58ff81d0fb27b3f0be76",
+    "wof:geomhash":"a69eb2c32c2d2827d4bd9532a56adbc8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091918593,
-    "wof:lastmodified":1690925027,
+    "wof:lastmodified":1695886514,
     "wof:name":"Mudiyah",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/862/7/1091918627.geojson
+++ b/data/109/191/862/7/1091918627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016995,
-    "geom:area_square_m":204152364.296244,
+    "geom:area_square_m":204152329.520583,
     "geom:bbox":"45.174973,13.644063,45.384717,13.804472",
     "geom:latitude":13.715741,
     "geom:longitude":45.28116,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AB.RA",
         "wd:id":"Q4117586"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892939,
-    "wof:geomhash":"a45b789fb34f52a454b0f78020203dd3",
+    "wof:geomhash":"d717247cdf9d2faa37b04ef90299e230",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091918627,
-    "wof:lastmodified":1690925038,
+    "wof:lastmodified":1695886516,
     "wof:name":"Rasad",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/865/3/1091918653.geojson
+++ b/data/109/191/865/3/1091918653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.066262,
-    "geom:area_square_m":796465228.106991,
+    "geom:area_square_m":796465188.960138,
     "geom:bbox":"45.181921,13.410977,45.521086,13.756449",
     "geom:latitude":13.571278,
     "geom:longitude":45.365697,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AB.SA",
         "wd:id":"Q4117544"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892940,
-    "wof:geomhash":"19a64f14b20a30880988485ff060d399",
+    "wof:geomhash":"be850cd72ef6b4d5896da35f5d6630f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918653,
-    "wof:lastmodified":1690925038,
+    "wof:lastmodified":1695886517,
     "wof:name":"Sarar",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/868/5/1091918685.geojson
+++ b/data/109/191/868/5/1091918685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027307,
-    "geom:area_square_m":327888363.699421,
+    "geom:area_square_m":327888357.70318,
     "geom:bbox":"45.300366,13.706555,45.504002,13.912143",
     "geom:latitude":13.819058,
     "geom:longitude":45.399626,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AB.SI",
         "wd:id":"Q4117509"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892941,
-    "wof:geomhash":"844b05fbdeddf5086fce0e7894520034",
+    "wof:geomhash":"caf2f0f89fc9762f3cc9696fc146faa2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091918685,
-    "wof:lastmodified":1690925027,
+    "wof:lastmodified":1695886514,
     "wof:name":"Sibah",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/869/7/1091918697.geojson
+++ b/data/109/191/869/7/1091918697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007715,
-    "geom:area_square_m":92897583.947357,
+    "geom:area_square_m":92897670.725172,
     "geom:bbox":"45.359254,13.077361,45.494898,13.192527",
     "geom:latitude":13.141485,
     "geom:longitude":45.422452,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.AB.ZI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892942,
-    "wof:geomhash":"998dc01aef2b00644d39eac5fa5e7b8d",
+    "wof:geomhash":"f1ec9388dd934e5f253e5fb41c29ec9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091918697,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886234,
     "wof:name":"Zingibar",
     "wof:parent_id":85681043,
     "wof:placetype":"county",

--- a/data/109/191/872/9/1091918729.geojson
+++ b/data/109/191/872/9/1091918729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043965,
-    "geom:area_square_m":530094109.049125,
+    "geom:area_square_m":530093924.434339,
     "geom:bbox":"44.408404,12.667916,44.958582,12.91037",
     "geom:latitude":12.814018,
     "geom:longitude":44.7275,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.AD.BU",
         "wd:id":"Q1658716"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892943,
-    "wof:geomhash":"0a1aab849dcb79ef69fa4705311c21ad",
+    "wof:geomhash":"5cb6f94e18706738a72be74453d9f31f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091918729,
-    "wof:lastmodified":1690925026,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Buraiqeh",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/876/1/1091918761.geojson
+++ b/data/109/191/876/1/1091918761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002909,
-    "geom:area_square_m":35065384.839771,
+    "geom:area_square_m":35065494.279709,
     "geom:bbox":"44.929029,12.82375,45.021706,12.883157",
     "geom:latitude":12.855367,
     "geom:longitude":44.973445,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.AD.MA",
         "wd:id":"Q3696034"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892944,
-    "wof:geomhash":"b7373d8d6ef499064cacae682b6ccd80",
+    "wof:geomhash":"e3304b5c8eb5b4f7119c087fe554af02",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091918761,
-    "wof:lastmodified":1690925037,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Mansura",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/878/9/1091918789.geojson
+++ b/data/109/191/878/9/1091918789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001561,
-    "geom:area_square_m":18828893.143288,
+    "geom:area_square_m":18828860.624486,
     "geom:bbox":"43.388668,12.631222,45.027289,12.796835",
     "geom:latitude":12.692929,
     "geom:longitude":43.889605,
@@ -107,9 +107,10 @@
         "hasc:id":"YE.AD.MU",
         "wd:id":"Q3696048"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892945,
-    "wof:geomhash":"1f1544bb2bd0cdffc206011df216ac38",
+    "wof:geomhash":"93e4af9e25b5d41c0262d057fee9b0c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1091918789,
-    "wof:lastmodified":1690925037,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Mualla",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/882/3/1091918823.geojson
+++ b/data/109/191/882/3/1091918823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002204,
-    "geom:area_square_m":26563322.949003,
+    "geom:area_square_m":26563346.921703,
     "geom:bbox":"44.98339,12.84532,45.05029,12.922499",
     "geom:latitude":12.882715,
     "geom:longitude":45.02273,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.AD.SO",
         "wd:id":"Q4804444"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892946,
-    "wof:geomhash":"c0f7141105048b13b155fa78cae4451b",
+    "wof:geomhash":"51700251360f4a105e36db737f6fa13a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091918823,
-    "wof:lastmodified":1690925036,
+    "wof:lastmodified":1695886516,
     "wof:name":"Ash Shaikh Outhman",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/883/9/1091918839.geojson
+++ b/data/109/191/883/9/1091918839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000883,
-    "geom:area_square_m":10652369.065951,
+    "geom:area_square_m":10652123.090636,
     "geom:bbox":"44.972027,12.751223,45.019684,12.791907",
     "geom:latitude":12.772134,
     "geom:longitude":44.998539,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.AD.AT",
         "wd:id":"Q4818151"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892947,
-    "wof:geomhash":"59595961492acdfb4e2e138f499b066c",
+    "wof:geomhash":"571169e2caefaa9e76a49266c636583b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091918839,
-    "wof:lastmodified":1690925035,
+    "wof:lastmodified":1695886516,
     "wof:name":"Attawahi",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/887/3/1091918873.geojson
+++ b/data/109/191/887/3/1091918873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001071,
-    "geom:area_square_m":12917302.011091,
+    "geom:area_square_m":12917350.719294,
     "geom:bbox":"45.018296,12.749556,45.05711,12.795647",
     "geom:latitude":12.771492,
     "geom:longitude":45.033519,
@@ -128,9 +128,10 @@
         "hasc:id":"YE.AD.CR",
         "wd:id":"Q2263449"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892948,
-    "wof:geomhash":"3b7bf4d8db52364888c07a636e2c208d",
+    "wof:geomhash":"6ed2590e940a4dcedb7d5db4a931d201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1091918873,
-    "wof:lastmodified":1690925026,
+    "wof:lastmodified":1695886514,
     "wof:name":"Craiter",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/890/5/1091918905.geojson
+++ b/data/109/191/890/5/1091918905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0056,
-    "geom:area_square_m":67490583.377126,
+    "geom:area_square_m":67490438.117528,
     "geom:bbox":"44.907969,12.87619,45.05023,12.941416",
     "geom:latitude":12.909453,
     "geom:longitude":44.977881,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.AD.DS",
         "wd:id":"Q4117565"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892949,
-    "wof:geomhash":"7ac55b7db3a77448fb40bd5dd19b3974",
+    "wof:geomhash":"97a28cee5a2aef2414c3515a78af48fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091918905,
-    "wof:lastmodified":1690925039,
+    "wof:lastmodified":1695886517,
     "wof:name":"Dar Sad",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/893/7/1091918937.geojson
+++ b/data/109/191/893/7/1091918937.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004651,
-    "geom:area_square_m":56058415.82247,
+    "geom:area_square_m":56058482.471566,
     "geom:bbox":"45.00872,12.794213,45.10085,12.943596",
     "geom:latitude":12.877727,
     "geom:longitude":45.05396,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AD.KM",
         "wd:id":"Q6403050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892950,
-    "wof:geomhash":"20f0160a823c5ccb60a4cfe82563d1e0",
+    "wof:geomhash":"a11097a894673966fc84211aeb9d17d5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918937,
-    "wof:lastmodified":1690925029,
+    "wof:lastmodified":1695886515,
     "wof:name":"Khur Maksar",
     "wof:parent_id":85681039,
     "wof:placetype":"county",

--- a/data/109/191/896/5/1091918965.geojson
+++ b/data/109/191/896/5/1091918965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02232,
-    "geom:area_square_m":267358252.872131,
+    "geom:area_square_m":267358317.487837,
     "geom:bbox":"44.672811,14.262177,44.88263,14.480735",
     "geom:latitude":14.372345,
     "geom:longitude":44.770046,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.AR",
         "wd:id":"Q4117776"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892951,
-    "wof:geomhash":"76ef6861faa3d612f0051e9cae104025",
+    "wof:geomhash":"808c28be43299ce5dff73908083c18da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091918965,
-    "wof:lastmodified":1690925038,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al A'rsh",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/899/3/1091918993.geojson
+++ b/data/109/191/899/3/1091918993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040564,
-    "geom:area_square_m":486569907.189385,
+    "geom:area_square_m":486569434.898574,
     "geom:bbox":"45.448617,13.888588,45.64943,14.23253",
     "geom:latitude":14.05508,
     "geom:longitude":45.553419,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"YE.BA.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892952,
-    "wof:geomhash":"935f91cacc394483b54bbb35bc6dcc5c",
+    "wof:geomhash":"5691ea59c3e9daf43052e30021603711",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091918993,
-    "wof:lastmodified":1636497424,
+    "wof:lastmodified":1695886735,
     "wof:name":"Al Bayda",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/902/1/1091919021.geojson
+++ b/data/109/191/902/1/1091919021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001252,
-    "geom:area_square_m":15023036.187262,
+    "geom:area_square_m":15022972.074184,
     "geom:bbox":"45.526513,13.970302,45.588968,13.996521",
     "geom:latitude":13.983553,
     "geom:longitude":45.560103,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.BC",
         "wd:id":"Q4703572"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892953,
-    "wof:geomhash":"3381c42ec120dba7e0d0f88c8df099f1",
+    "wof:geomhash":"fb05052596c128c41a6c1305776fbcf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919021,
-    "wof:lastmodified":1690925035,
+    "wof:lastmodified":1695886515,
     "wof:name":"Al Bayda City",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/905/5/1091919055.geojson
+++ b/data/109/191/905/5/1091919055.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028541,
-    "geom:area_square_m":341893186.468378,
+    "geom:area_square_m":341892832.873636,
     "geom:bbox":"45.279243,14.237442,45.48967,14.494002",
     "geom:latitude":14.35994,
     "geom:longitude":45.38985,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.ML",
         "wd:id":"Q4117799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892954,
-    "wof:geomhash":"debfcc8fd3767787bca917c1452def3c",
+    "wof:geomhash":"818e4fdcbd29a572aa62f53dc7d89c53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919055,
-    "wof:lastmodified":1690925034,
+    "wof:lastmodified":1695886515,
     "wof:name":"Al Malagim",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/908/3/1091919083.geojson
+++ b/data/109/191/908/3/1091919083.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062238,
-    "geom:area_square_m":744754134.33955,
+    "geom:area_square_m":744754810.159727,
     "geom:bbox":"44.761703,14.402816,45.019462,14.8048",
     "geom:latitude":14.591875,
     "geom:longitude":44.90257,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.QU",
         "wd:id":"Q4118316"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892956,
-    "wof:geomhash":"d4167641118cda16028ffd112bd938e8",
+    "wof:geomhash":"b295a4d59c135c921aa333cb098aa20a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919083,
-    "wof:lastmodified":1690925024,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Quraishyah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/910/9/1091919109.geojson
+++ b/data/109/191/910/9/1091919109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01491,
-    "geom:area_square_m":178700478.596329,
+    "geom:area_square_m":178700385.165556,
     "geom:bbox":"44.657476,14.179471,44.895014,14.306967",
     "geom:latitude":14.244745,
     "geom:longitude":44.782608,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.RY",
         "wd:id":"Q4117791"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892957,
-    "wof:geomhash":"fc8b593f93fac2c6a11649c390a3d978",
+    "wof:geomhash":"5c5063ae3ee68a56ce77914bbe5fbcf5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919109,
-    "wof:lastmodified":1690925041,
+    "wof:lastmodified":1695886517,
     "wof:name":"Ar Ryashyyah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/913/5/1091919135.geojson
+++ b/data/109/191/913/5/1091919135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037417,
-    "geom:area_square_m":448121634.038828,
+    "geom:area_square_m":448121589.968257,
     "geom:bbox":"45.176446,14.19008,45.447815,14.634313",
     "geom:latitude":14.407038,
     "geom:longitude":45.310247,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.SD",
         "wd:id":"Q4118414"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892958,
-    "wof:geomhash":"67fe31f98062405727c3d261c7013ac5",
+    "wof:geomhash":"b8c4b6a53f61444af1a268a410b03e9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919135,
-    "wof:lastmodified":1690925031,
+    "wof:lastmodified":1695886515,
     "wof:name":"As Sawadiyah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/916/7/1091919167.geojson
+++ b/data/109/191/916/7/1091919167.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08168,
-    "geom:area_square_m":979179616.819455,
+    "geom:area_square_m":979179596.294936,
     "geom:bbox":"45.602517,13.992596,46.060328,14.342567",
     "geom:latitude":14.18922,
     "geom:longitude":45.791625,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.SM",
         "wd:id":"Q4117807"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892959,
-    "wof:geomhash":"7321ecb073d30cb1667be2cf15fa3214",
+    "wof:geomhash":"a53ef4a5baab8fe42d61353b6f671a77",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919167,
-    "wof:lastmodified":1690925040,
+    "wof:lastmodified":1695886517,
     "wof:name":"As Sawma'ah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/920/3/1091919203.geojson
+++ b/data/109/191/920/3/1091919203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.080755,
-    "geom:area_square_m":967542460.765007,
+    "geom:area_square_m":967542588.455328,
     "geom:bbox":"44.950679,14.066462,45.219369,14.533281",
     "geom:latitude":14.315983,
     "geom:longitude":45.091423,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.BA.SH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892960,
-    "wof:geomhash":"c9ba51e7d498a3daf32eb61f24dee968",
+    "wof:geomhash":"bc4e8d36c239c6e1d103fd2053a09318",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091919203,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886233,
     "wof:name":"Ash Sharyah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/923/7/1091919237.geojson
+++ b/data/109/191/923/7/1091919237.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078826,
-    "geom:area_square_m":945000523.377153,
+    "geom:area_square_m":945000988.507177,
     "geom:bbox":"45.136077,13.966934,45.580237,14.428927",
     "geom:latitude":14.178811,
     "geom:longitude":45.355719,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.TA",
         "wd:id":"Q4117705"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892961,
-    "wof:geomhash":"32c462dcbe62b6a8dcf9495b7b24b4ff",
+    "wof:geomhash":"ae6f53ef388e6b3395462eb598199fa8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919237,
-    "wof:lastmodified":1690925030,
+    "wof:lastmodified":1695886515,
     "wof:name":"At Taffah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/926/5/1091919265.geojson
+++ b/data/109/191/926/5/1091919265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015044,
-    "geom:area_square_m":180513779.115198,
+    "geom:area_square_m":180513811.203811,
     "geom:bbox":"45.356031,13.890591,45.489063,14.090796",
     "geom:latitude":13.984675,
     "geom:longitude":45.421256,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.BA.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892963,
-    "wof:geomhash":"d5d816ee64bdd79103b741fe70b7d7a0",
+    "wof:geomhash":"0691f02be554b8f3f478521805c836a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091919265,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886233,
     "wof:name":"Az Zahir",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/929/9/1091919299.geojson
+++ b/data/109/191/929/9/1091919299.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014153,
-    "geom:area_square_m":169735110.122821,
+    "geom:area_square_m":169735330.113226,
     "geom:bbox":"45.397604,14.028393,45.530631,14.197693",
     "geom:latitude":14.100146,
     "geom:longitude":45.463766,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.DN",
         "wd:id":"Q4117714"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892964,
-    "wof:geomhash":"46f55ac6c6e9313b58822ee1d7c015a5",
+    "wof:geomhash":"fac4a7ae76187e2e3f75bef718fa0bf8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919299,
-    "wof:lastmodified":1690925040,
+    "wof:lastmodified":1695886517,
     "wof:name":"Dhi Na'im",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/933/3/1091919333.geojson
+++ b/data/109/191/933/3/1091919333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069253,
-    "geom:area_square_m":829428182.194689,
+    "geom:area_square_m":829428063.782074,
     "geom:bbox":"45.560729,14.21021,45.849789,14.594997",
     "geom:latitude":14.399778,
     "geom:longitude":45.708563,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.MS",
         "wd:id":"Q4117716"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892965,
-    "wof:geomhash":"d28328bb8451ca6d9a484f58f54c1598",
+    "wof:geomhash":"7c8bfeb162e812327cc68dde22ae7fb7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919333,
-    "wof:lastmodified":1690925035,
+    "wof:lastmodified":1695886515,
     "wof:name":"Maswarah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/938/1/1091919381.geojson
+++ b/data/109/191/938/1/1091919381.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065735,
-    "geom:area_square_m":788630997.857701,
+    "geom:area_square_m":788631373.234213,
     "geom:bbox":"45.56011,13.83133,46.028245,14.233037",
     "geom:latitude":14.013543,
     "geom:longitude":45.807162,
@@ -79,9 +79,10 @@
     "wof:concordances":{
         "hasc:id":"YE.BA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892966,
-    "wof:geomhash":"75cdc353bb545d0411b30be9e601dcdf",
+    "wof:geomhash":"03e9f9d60b8107f734ac603f38fdd8da",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1091919381,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886234,
     "wof:name":"Mukayras",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/941/5/1091919415.geojson
+++ b/data/109/191/941/5/1091919415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021775,
-    "geom:area_square_m":260562018.65912,
+    "geom:area_square_m":260562464.096714,
     "geom:bbox":"45.436072,14.474951,45.621228,14.712884",
     "geom:latitude":14.60085,
     "geom:longitude":45.52023,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.NM",
         "wd:id":"Q4117725"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892967,
-    "wof:geomhash":"3a0987b717ca19b8c1b16119d5c0b8de",
+    "wof:geomhash":"fa143438e93f0fd276e5dab9b67026f5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919415,
-    "wof:lastmodified":1690925029,
+    "wof:lastmodified":1695886515,
     "wof:name":"Na'man",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/945/1/1091919451.geojson
+++ b/data/109/191/945/1/1091919451.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030309,
-    "geom:area_square_m":362779707.689279,
+    "geom:area_square_m":362779533.108031,
     "geom:bbox":"45.483506,14.38957,45.682792,14.719132",
     "geom:latitude":14.536864,
     "geom:longitude":45.59062,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.NT",
         "wd:id":"Q4117794"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892968,
-    "wof:geomhash":"e6c41ca92887ba1af94c08e4a305d373",
+    "wof:geomhash":"ae80cd478b477709c41b0ecbfe49c201",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919451,
-    "wof:lastmodified":1690925041,
+    "wof:lastmodified":1695886517,
     "wof:name":"Nati'",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/947/9/1091919479.geojson
+++ b/data/109/191/947/9/1091919479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019082,
-    "geom:area_square_m":228609614.679703,
+    "geom:area_square_m":228609213.490647,
     "geom:bbox":"44.817763,14.228934,44.969126,14.443827",
     "geom:latitude":14.333069,
     "geom:longitude":44.906172,
@@ -105,9 +105,10 @@
         "hasc:id":"YE.BA.RD",
         "wd:id":"Q4118334"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892969,
-    "wof:geomhash":"6a598b8cf6c88d781f671a18d62929f9",
+    "wof:geomhash":"bd9a9554447162b33edb2b26f4fd9113",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091919479,
-    "wof:lastmodified":1690925031,
+    "wof:lastmodified":1695886515,
     "wof:name":"Rada'",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/950/9/1091919509.geojson
+++ b/data/109/191/950/9/1091919509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022723,
-    "geom:area_square_m":272065531.749425,
+    "geom:area_square_m":272065672.140972,
     "geom:bbox":"45.185694,14.378185,45.36249,14.586368",
     "geom:latitude":14.467196,
     "geom:longitude":45.268415,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.RA",
         "wd:id":"Q4117692"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892970,
-    "wof:geomhash":"0a81328c792fa893df4deba50932a4db",
+    "wof:geomhash":"4ac8b6758a7cb64110af89a46ffda536",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919509,
-    "wof:lastmodified":1690925032,
+    "wof:lastmodified":1695886515,
     "wof:name":"Radman Al Awad",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/953/3/1091919533.geojson
+++ b/data/109/191/953/3/1091919533.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017372,
-    "geom:area_square_m":208165352.878816,
+    "geom:area_square_m":208165321.12613,
     "geom:bbox":"44.587367,14.180136,44.753759,14.368607",
     "geom:latitude":14.284741,
     "geom:longitude":44.663609,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.SB",
         "wd:id":"Q4117712"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892972,
-    "wof:geomhash":"be2118ed85a656f41dd32186eba008e7",
+    "wof:geomhash":"ab8ae3d8014ce2e9af70288a73b93463",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919533,
-    "wof:lastmodified":1690925022,
+    "wof:lastmodified":1695886513,
     "wof:name":"Sabah",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/955/9/1091919559.geojson
+++ b/data/109/191/955/9/1091919559.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053351,
-    "geom:area_square_m":638348456.264355,
+    "geom:area_square_m":638347869.634627,
     "geom:bbox":"44.706236,14.414563,45.114036,14.823668",
     "geom:latitude":14.616078,
     "geom:longitude":44.916333,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.BA.WR",
         "wd:id":"Q4118409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892973,
-    "wof:geomhash":"325252abd4debdf328f3e4c497c8fda3",
+    "wof:geomhash":"73f48f5adfda66a70d73ad1657c47d21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919559,
-    "wof:lastmodified":1690925025,
+    "wof:lastmodified":1695886514,
     "wof:name":"Wald Rabi'",
     "wof:parent_id":85681001,
     "wof:placetype":"county",

--- a/data/109/191/959/5/1091919595.geojson
+++ b/data/109/191/959/5/1091919595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029022,
-    "geom:area_square_m":348606314.768273,
+    "geom:area_square_m":348606512.367304,
     "geom:bbox":"44.559727,13.583873,44.8376,13.842093",
     "geom:latitude":13.731755,
     "geom:longitude":44.710253,
@@ -108,9 +108,10 @@
         "hasc:id":"YE.DL.DH",
         "wd:id":"Q1884227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892974,
-    "wof:geomhash":"593e99e7e77350b4c240ebc5fca9c286",
+    "wof:geomhash":"42b01aca9c4cd315116cbc0845929379",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -120,7 +121,7 @@
         }
     ],
     "wof:id":1091919595,
-    "wof:lastmodified":1690925033,
+    "wof:lastmodified":1695886515,
     "wof:name":"Ad Dhale'e",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/962/5/1091919625.geojson
+++ b/data/109/191/962/5/1091919625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03005,
-    "geom:area_square_m":361104198.933831,
+    "geom:area_square_m":361104004.54241,
     "geom:bbox":"44.513495,13.549716,44.761332,13.743489",
     "geom:latitude":13.634773,
     "geom:longitude":44.626154,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.DL.AZ",
         "wd:id":"Q4117306"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892975,
-    "wof:geomhash":"86e978cc8c40c4ba024990584f769df9",
+    "wof:geomhash":"582e6ccdcbafb83748526bf4fa6dee16",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091919625,
-    "wof:lastmodified":1690925023,
+    "wof:lastmodified":1695886513,
     "wof:name":"Al Azariq",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/965/7/1091919657.geojson
+++ b/data/109/191/965/7/1091919657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038212,
-    "geom:area_square_m":458955265.304779,
+    "geom:area_square_m":458955211.74527,
     "geom:bbox":"44.368436,13.61623,44.569573,13.881988",
     "geom:latitude":13.753905,
     "geom:longitude":44.468662,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.HU",
         "wd:id":"Q4117227"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892976,
-    "wof:geomhash":"0bdbd7d708994daee4e26760222c31d8",
+    "wof:geomhash":"53a28d950a96fccdf0946196b86b055a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919657,
-    "wof:lastmodified":1690925023,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Husha",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/967/5/1091919675.geojson
+++ b/data/109/191/967/5/1091919675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014827,
-    "geom:area_square_m":178054236.201154,
+    "geom:area_square_m":178054276.236293,
     "geom:bbox":"44.715259,13.717281,44.940124,13.860462",
     "geom:latitude":13.784709,
     "geom:longitude":44.814508,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.HN",
         "wd:id":"Q4117328"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892977,
-    "wof:geomhash":"76c7afc982a5bd13d4148c0ad99adc75",
+    "wof:geomhash":"eaf535c04018b27bbaefe1fdcf44bc59",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919675,
-    "wof:lastmodified":1690925033,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Hussein",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/969/7/1091919697.geojson
+++ b/data/109/191/969/7/1091919697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026041,
-    "geom:area_square_m":312658328.737549,
+    "geom:area_square_m":312658183.934248,
     "geom:bbox":"44.802919,13.753983,45.114171,13.913252",
     "geom:latitude":13.84051,
     "geom:longitude":44.934565,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.SH",
         "wd:id":"Q4117318"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892978,
-    "wof:geomhash":"cca438b82e6bd78cd28edbd89878971b",
+    "wof:geomhash":"d8041b3cd67a12db6bdb5723c6df7998",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919697,
-    "wof:lastmodified":1690925034,
+    "wof:lastmodified":1695886516,
     "wof:name":"Ash Shu'ayb",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/972/5/1091919725.geojson
+++ b/data/109/191/972/5/1091919725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032963,
-    "geom:area_square_m":395328992.665626,
+    "geom:area_square_m":395329238.520978,
     "geom:bbox":"44.55085,13.987018,44.804121,14.217711",
     "geom:latitude":14.094422,
     "geom:longitude":44.69161,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.DA",
         "wd:id":"Q4117240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892979,
-    "wof:geomhash":"c710ed6d889edfd113f78e14e90533a8",
+    "wof:geomhash":"b6e675cb0e56a1018f96616424cf6cd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919725,
-    "wof:lastmodified":1690925042,
+    "wof:lastmodified":1695886517,
     "wof:name":"Damt",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/975/1/1091919751.geojson
+++ b/data/109/191/975/1/1091919751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005794,
-    "geom:area_square_m":69604363.617217,
+    "geom:area_square_m":69604404.957577,
     "geom:bbox":"44.597939,13.683099,44.715685,13.768169",
     "geom:latitude":13.721724,
     "geom:longitude":44.666928,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.JA",
         "wd:id":"Q4117376"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892980,
-    "wof:geomhash":"873cf19b63c776bd7e26f2bf289b99bc",
+    "wof:geomhash":"807d47ca0e755b00de536828ebbbd595",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919751,
-    "wof:lastmodified":1690925042,
+    "wof:lastmodified":1695886517,
     "wof:name":"Jahaf",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/978/1/1091919781.geojson
+++ b/data/109/191/978/1/1091919781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.100178,
-    "geom:area_square_m":1201688880.255149,
+    "geom:area_square_m":1201688693.529531,
     "geom:bbox":"44.770199,13.86619,45.15498,14.234677",
     "geom:latitude":14.044336,
     "geom:longitude":44.957644,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DL.JU",
         "wd:id":"Q4117516"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892981,
-    "wof:geomhash":"a9cd17e02d4968e0c9fffdc1c47d88a3",
+    "wof:geomhash":"7fe5523d37a29759059053417fbef216",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919781,
-    "wof:lastmodified":1690925030,
+    "wof:lastmodified":1695886515,
     "wof:name":"Juban",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/980/1/1091919801.geojson
+++ b/data/109/191/980/1/1091919801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057171,
-    "geom:area_square_m":686154935.844037,
+    "geom:area_square_m":686154790.148748,
     "geom:bbox":"44.435081,13.812211,44.821387,14.040562",
     "geom:latitude":13.924432,
     "geom:longitude":44.648466,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.DL.QA",
         "wd:id":"Q1884217"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892983,
-    "wof:geomhash":"78a5c9d41fb34c58eb258a0c28ccf838",
+    "wof:geomhash":"9fe31ca99bb54e29dfc4e5521a767246",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091919801,
-    "wof:lastmodified":1690925041,
+    "wof:lastmodified":1695886517,
     "wof:name":"Qa'atabah",
     "wof:parent_id":85681003,
     "wof:placetype":"county",

--- a/data/109/191/983/5/1091919835.geojson
+++ b/data/109/191/983/5/1091919835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0211,
-    "geom:area_square_m":251752592.363172,
+    "geom:area_square_m":251752578.77988,
     "geom:bbox":"42.983372,15.150781,43.401738,15.294225",
     "geom:latitude":15.219005,
     "geom:longitude":43.184812,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.HU.DA",
         "wd:id":"Q4117503"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892984,
-    "wof:geomhash":"0ae22e2e566a09d8467545a0e43945df",
+    "wof:geomhash":"3e0e7aa5f3a71af0caf5c841169f3981",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091919835,
-    "wof:lastmodified":1690925029,
+    "wof:lastmodified":1695886515,
     "wof:name":"Ad Dahi",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/191/986/9/1091919869.geojson
+++ b/data/109/191/986/9/1091919869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056427,
-    "geom:area_square_m":675151196.135105,
+    "geom:area_square_m":675151665.794219,
     "geom:bbox":"42.899555,14.380112,43.24531,14.827952",
     "geom:latitude":14.61471,
     "geom:longitude":43.083391,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.DU",
         "wd:id":"Q4117496"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892985,
-    "wof:geomhash":"076cd2728e60d2bd7d89a28ba4b27c2b",
+    "wof:geomhash":"adc27c45b427742b17ac3d187ca9e121",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919869,
-    "wof:lastmodified":1690925043,
+    "wof:lastmodified":1695886517,
     "wof:name":"Ad Durayhimi",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/191/990/3/1091919903.geojson
+++ b/data/109/191/990/3/1091919903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04889,
-    "geom:area_square_m":586370937.880017,
+    "geom:area_square_m":586370789.980552,
     "geom:bbox":"43.276675,13.900293,43.531111,14.303443",
     "geom:latitude":14.078168,
     "geom:longitude":43.385386,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.GA",
         "wd:id":"Q4117451"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892986,
-    "wof:geomhash":"008c571bc00e80655bdddc486e9913bd",
+    "wof:geomhash":"2240d25c1e8840449fa84af7b6e5ba7a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919903,
-    "wof:lastmodified":1690925024,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Garrahi",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/191/992/7/1091919927.geojson
+++ b/data/109/191/992/7/1091919927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008553,
-    "geom:area_square_m":102169325.418883,
+    "geom:area_square_m":102169397.861988,
     "geom:bbox":"43.498726,14.932993,43.664127,15.044265",
     "geom:latitude":14.980687,
     "geom:longitude":43.579417,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.HJ",
         "wd:id":"Q4117457"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892987,
-    "wof:geomhash":"3d09a5d87a61f2869aa4f4ed1afa35a5",
+    "wof:geomhash":"10c23bcc80f6ffde250b0d58960a87cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919927,
-    "wof:lastmodified":1690925032,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Hajjaylah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/191/995/5/1091919955.geojson
+++ b/data/109/191/995/5/1091919955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009077,
-    "geom:area_square_m":108509303.239637,
+    "geom:area_square_m":108509289.214551,
     "geom:bbox":"42.876221,14.777635,43.074413,14.873157",
     "geom:latitude":14.819401,
     "geom:longitude":42.99395,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.HL",
         "wd:id":"Q4117610"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892988,
-    "wof:geomhash":"457b16faf896fe917b18388eb25a1411",
+    "wof:geomhash":"0c74fff1706cf102412d61ca73539c35",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919955,
-    "wof:lastmodified":1690925032,
+    "wof:lastmodified":1695886516,
     "wof:name":"Al Hali",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/191/998/3/1091919983.geojson
+++ b/data/109/191/998/3/1091919983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004652,
-    "geom:area_square_m":55621862.745086,
+    "geom:area_square_m":55621850.211382,
     "geom:bbox":"42.942058,14.726396,43.055722,14.799317",
     "geom:latitude":14.758863,
     "geom:longitude":42.996171,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.HW",
         "wd:id":"Q4117595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892989,
-    "wof:geomhash":"98aba7deb0456d35dc2eac7bf22a25ef",
+    "wof:geomhash":"05e8ba14e3fb5981a86416517f47aea8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091919983,
-    "wof:lastmodified":1690925023,
+    "wof:lastmodified":1695886514,
     "wof:name":"Al Hawak",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/001/3/1091920013.geojson
+++ b/data/109/192/001/3/1091920013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04649,
-    "geom:area_square_m":558252991.35181,
+    "geom:area_square_m":558253070.204038,
     "geom:bbox":"42.662918,13.649555,43.478296,13.944657",
     "geom:latitude":13.80282,
     "geom:longitude":43.265289,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.HU.KH",
         "wd:id":"Q4704229"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892990,
-    "wof:geomhash":"be9c8cee85a6d551662a89d31324f4ca",
+    "wof:geomhash":"43eb8797783c239dbf4b9ba09bdc59ac",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920013,
-    "wof:lastmodified":1690924953,
+    "wof:lastmodified":1695886499,
     "wof:name":"Al Khawkhah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/004/5/1091920045.geojson
+++ b/data/109/192/004/5/1091920045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016253,
-    "geom:area_square_m":194409065.586977,
+    "geom:area_square_m":194409277.63191,
     "geom:bbox":"43.260357,14.636531,43.478629,14.743363",
     "geom:latitude":14.686896,
     "geom:longitude":43.372311,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.MS",
         "wd:id":"Q4117598"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892991,
-    "wof:geomhash":"eddf377ed986f24054b6cf54c0810f03",
+    "wof:geomhash":"7254554bce3793bef0bbb659c66df4a5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920045,
-    "wof:lastmodified":1690924998,
+    "wof:lastmodified":1695886508,
     "wof:name":"Al Mansuriyah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/006/5/1091920065.geojson
+++ b/data/109/192/006/5/1091920065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062705,
-    "geom:area_square_m":749389279.698473,
+    "geom:area_square_m":749389593.268826,
     "geom:bbox":"42.991625,14.688799,43.401801,14.981046",
     "geom:latitude":14.869305,
     "geom:longitude":43.210481,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.MR",
         "wd:id":"Q4117620"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892992,
-    "wof:geomhash":"35a84afdf599e769843f82e0ac591e02",
+    "wof:geomhash":"d29a24762db874ccab8d0921ce39be76",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920065,
-    "wof:lastmodified":1690924956,
+    "wof:lastmodified":1695886500,
     "wof:name":"Al Marawi'ah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/009/7/1091920097.geojson
+++ b/data/109/192/009/7/1091920097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014278,
-    "geom:area_square_m":170279304.188613,
+    "geom:area_square_m":170279137.594581,
     "geom:bbox":"43.091249,15.254397,43.271568,15.369533",
     "geom:latitude":15.314798,
     "geom:longitude":43.181301,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.MG",
         "wd:id":"Q4117529"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892993,
-    "wof:geomhash":"766825c1f64ce0ca1301f4c3010bd7a2",
+    "wof:geomhash":"483317b2b76f9a2aa3387f0b5573888e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920097,
-    "wof:lastmodified":1690924945,
+    "wof:lastmodified":1695886497,
     "wof:name":"Al Mighlaf",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/012/5/1091920125.geojson
+++ b/data/109/192/012/5/1091920125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00001,
-    "geom:area_square_m":120761.555617,
+    "geom:area_square_m":120759.952433,
     "geom:bbox":"42.941213,14.796932,42.951506,14.799317",
     "geom:latitude":14.798379,
     "geom:longitude":42.94492,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.MI",
         "wd:id":"Q4117627"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892994,
-    "wof:geomhash":"af1f057b80816d3cc5f9131aee36ab79",
+    "wof:geomhash":"fd887ed84f68087e87b56aa73e6216ff",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920125,
-    "wof:lastmodified":1690924929,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Mina",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/016/5/1091920165.geojson
+++ b/data/109/192/016/5/1091920165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05189,
-    "geom:area_square_m":618715777.603207,
+    "geom:area_square_m":618715569.363343,
     "geom:bbox":"42.771686,15.151419,43.032904,15.552216",
     "geom:latitude":15.356315,
     "geom:longitude":42.891228,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HU.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892996,
-    "wof:geomhash":"9cc7be045f7d0f217be848ece8405e7e",
+    "wof:geomhash":"2933ca62daabcfc10cac033fc5f45714",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091920165,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886233,
     "wof:name":"Al Munirah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/019/1/1091920191.geojson
+++ b/data/109/192/019/1/1091920191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032378,
-    "geom:area_square_m":385869027.357916,
+    "geom:area_square_m":385869005.554171,
     "geom:bbox":"42.925797,15.280928,43.254738,15.560164",
     "geom:latitude":15.465019,
     "geom:longitude":43.114685,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.QA",
         "wd:id":"Q4117609"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892997,
-    "wof:geomhash":"19fa35b899ae7e0a3fe68ae278d169d5",
+    "wof:geomhash":"d719adde4447b792e6270613f645ae68",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920191,
-    "wof:lastmodified":1690924995,
+    "wof:lastmodified":1695886507,
     "wof:name":"Al Qanawis",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/021/7/1091920217.geojson
+++ b/data/109/192/021/7/1091920217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107456,
-    "geom:area_square_m":1279567529.835822,
+    "geom:area_square_m":1279567651.770213,
     "geom:bbox":"41.822861,15.419556,43.164179,15.869976",
     "geom:latitude":15.631354,
     "geom:longitude":42.845732,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.HU.AL",
         "wd:id":"Q4733335"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892998,
-    "wof:geomhash":"b4330aa24d844a7be595e2bb8e3a9faa",
+    "wof:geomhash":"17ca15c659d4e56f20eecbc274c5dc08",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920217,
-    "wof:lastmodified":1690924996,
+    "wof:lastmodified":1695886508,
     "wof:name":"Alluheyah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/025/1/1091920251.geojson
+++ b/data/109/192/025/1/1091920251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01309,
-    "geom:area_square_m":156180175.047373,
+    "geom:area_square_m":156180044.244316,
     "geom:bbox":"42.158749,15.033722,42.782301,15.36625",
     "geom:latitude":15.22854,
     "geom:longitude":42.651233,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.HU.SA",
         "wd:id":"Q1884201"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473892999,
-    "wof:geomhash":"9ccfcefdb54f6eb744bf0abe902410e5",
+    "wof:geomhash":"32ab5e5fcbc211280c85aa13046f9d66",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091920251,
-    "wof:lastmodified":1690924935,
+    "wof:lastmodified":1695886495,
     "wof:name":"As Salif",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/027/1/1091920271.geojson
+++ b/data/109/192/027/1/1091920271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031972,
-    "geom:area_square_m":382296172.653576,
+    "geom:area_square_m":382295848.176658,
     "geom:bbox":"43.159372,14.64846,43.507067,14.848581",
     "geom:latitude":14.757462,
     "geom:longitude":43.334792,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.SU",
         "wd:id":"Q4117635"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893000,
-    "wof:geomhash":"6f8f29ab725505d9af512dff09ce3a36",
+    "wof:geomhash":"013f4dafb885cfe7f7a9036eb7c65461",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920271,
-    "wof:lastmodified":1690924984,
+    "wof:lastmodified":1695886505,
     "wof:name":"As Sukhnah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/028/9/1091920289.geojson
+++ b/data/109/192/028/9/1091920289.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068367,
-    "geom:area_square_m":819964552.639631,
+    "geom:area_square_m":819964849.465468,
     "geom:bbox":"42.677082,13.839556,43.302074,14.279725",
     "geom:latitude":14.08078,
     "geom:longitude":43.119866,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.HU.TU",
         "wd:id":"Q4117542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893002,
-    "wof:geomhash":"26ae45c9d314d87b9f49fcea919642a9",
+    "wof:geomhash":"ee5abd4862a3ad403ad895268a26f890",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920289,
-    "wof:lastmodified":1690924993,
+    "wof:lastmodified":1695886507,
     "wof:name":"At Tuhayat",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/031/9/1091920319.geojson
+++ b/data/109/192/031/9/1091920319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04175,
-    "geom:area_square_m":497943185.377146,
+    "geom:area_square_m":497943648.379524,
     "geom:bbox":"42.871041,15.152703,43.259515,15.451673",
     "geom:latitude":15.30076,
     "geom:longitude":43.046849,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.ZD",
         "wd:id":"Q4117462"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893003,
-    "wof:geomhash":"c6315d13b3896bb5344265dc5baa046a",
+    "wof:geomhash":"693c9a4d78d43ac15b1f1ae1ca72ed50",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920319,
-    "wof:lastmodified":1690924946,
+    "wof:lastmodified":1695886497,
     "wof:name":"Az Zaydiyah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/035/3/1091920353.geojson
+++ b/data/109/192/035/3/1091920353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.065353,
-    "geom:area_square_m":777810311.143553,
+    "geom:area_square_m":777810343.539812,
     "geom:bbox":"42.883733,15.557684,43.244037,15.876133",
     "geom:latitude":15.736837,
     "geom:longitude":43.101002,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.ZU",
         "wd:id":"Q4117630"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893004,
-    "wof:geomhash":"c5aab68da0a67d0c4cfb56179c24799f",
+    "wof:geomhash":"a189ae29f08423e533d6d337386e478e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920353,
-    "wof:lastmodified":1690925001,
+    "wof:lastmodified":1695886509,
     "wof:name":"Az Zuhrah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/038/7/1091920387.geojson
+++ b/data/109/192/038/7/1091920387.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020289,
-    "geom:area_square_m":242434960.389225,
+    "geom:area_square_m":242435032.924743,
     "geom:bbox":"43.382769,14.817773,43.571476,14.981511",
     "geom:latitude":14.910114,
     "geom:longitude":43.469342,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.HU.BU",
         "wd:id":"Q4117582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893005,
-    "wof:geomhash":"5ff7b15f8765aca8dbffcf7b9bf3b513",
+    "wof:geomhash":"d19187854dcc46c3ff4d8142fe249cf2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920387,
-    "wof:lastmodified":1690924943,
+    "wof:lastmodified":1695886496,
     "wof:name":"Bura",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/042/3/1091920423.geojson
+++ b/data/109/192/042/3/1091920423.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02205,
-    "geom:area_square_m":264624081.345037,
+    "geom:area_square_m":264623879.275528,
     "geom:bbox":"43.387546,13.827784,43.611062,14.040461",
     "geom:latitude":13.940927,
     "geom:longitude":43.496971,
@@ -110,9 +110,10 @@
         "hasc:id":"YE.HU.HS",
         "wd:id":"Q4117624"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893006,
-    "wof:geomhash":"c18a756e57b4d9a35abbf0a5daa5cad6",
+    "wof:geomhash":"f25df1407e52cf4a030b49eb26ae8c53",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1091920423,
-    "wof:lastmodified":1690924981,
+    "wof:lastmodified":1695886735,
     "wof:name":"Hays",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/044/1/1091920441.geojson
+++ b/data/109/192/044/1/1091920441.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034577,
-    "geom:area_square_m":414776593.243082,
+    "geom:area_square_m":414776768.261764,
     "geom:bbox":"43.477005,13.910701,43.775478,14.150166",
     "geom:latitude":14.038334,
     "geom:longitude":43.615149,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HU.JR",
         "wd:id":"Q4117601"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893007,
-    "wof:geomhash":"f6b8aab9556adc9ce5102fccb0670090",
+    "wof:geomhash":"84163c5e047bc43f8346ecbdd25ca48b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920441,
-    "wof:lastmodified":1690924990,
+    "wof:lastmodified":1695886507,
     "wof:name":"Jabal Ra's",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/047/5/1091920475.geojson
+++ b/data/109/192/047/5/1091920475.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009827,
-    "geom:area_square_m":117170437.469172,
+    "geom:area_square_m":117170356.413432,
     "geom:bbox":"42.505829,15.263695,42.645416,15.506862",
     "geom:latitude":15.355884,
     "geom:longitude":42.587471,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HU.KA",
         "wd:id":"Q17067582"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893009,
-    "wof:geomhash":"94a00b00d58adade4952b3e37988738c",
+    "wof:geomhash":"03f48c6618112a9ef5198ad17f90d269",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091920475,
-    "wof:lastmodified":1690924939,
+    "wof:lastmodified":1695886496,
     "wof:name":"Kamaran",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/109/192/051/1/1091920511.geojson
+++ b/data/109/192/051/1/1091920511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012828,
-    "geom:area_square_m":152413172.836515,
+    "geom:area_square_m":152413165.361182,
     "geom:bbox":"44.5965,16.02894,44.774553,16.153163",
     "geom:latitude":16.0818,
     "geom:longitude":44.687882,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.GH",
         "wd:id":"Q4117300"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893010,
-    "wof:geomhash":"df54768f829f9357b386c3f3a527cec7",
+    "wof:geomhash":"e15e2fecd4499d066a425849ef1891ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920511,
-    "wof:lastmodified":1690925008,
+    "wof:lastmodified":1695886510,
     "wof:name":"Al Ghayl",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/054/7/1091920547.geojson
+++ b/data/109/192/054/7/1091920547.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135478,
-    "geom:area_square_m":1609798464.864251,
+    "geom:area_square_m":1609799344.876442,
     "geom:bbox":"44.676967,15.771605,45.241337,16.309977",
     "geom:latitude":16.063959,
     "geom:longitude":45.004772,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.JA.HA",
         "wd:id":"Q4117277"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893011,
-    "wof:geomhash":"3f9c631846c2b2d199999d0d8cddf74a",
+    "wof:geomhash":"ffd0e0108ed99039a2d4cb6ef999efe3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920547,
-    "wof:lastmodified":1690924941,
+    "wof:lastmodified":1695886497,
     "wof:name":"Al Hazm",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/057/5/1091920575.geojson
+++ b/data/109/192/057/5/1091920575.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043344,
-    "geom:area_square_m":514014678.969519,
+    "geom:area_square_m":514015170.091846,
     "geom:bbox":"44.260347,16.362589,44.598177,16.57171",
     "geom:latitude":16.450909,
     "geom:longitude":44.414681,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.JA.HU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893012,
-    "wof:geomhash":"6b26353b47b86ad0f7b44f42b3686d72",
+    "wof:geomhash":"b7f65c5789b4d8a15cd8487ed9bb671c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091920575,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695886233,
     "wof:name":"Al Humaydat",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/060/5/1091920605.geojson
+++ b/data/109/192/060/5/1091920605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008034,
-    "geom:area_square_m":95460673.552839,
+    "geom:area_square_m":95460438.519873,
     "geom:bbox":"44.721022,16.028005,44.876997,16.110144",
     "geom:latitude":16.062453,
     "geom:longitude":44.798148,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.KH",
         "wd:id":"Q4117347"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893013,
-    "wof:geomhash":"12eb46af583eeb454fd0098fe2ec68e0",
+    "wof:geomhash":"b85693754547093935be22a98b0cbc39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920605,
-    "wof:lastmodified":1690925009,
+    "wof:lastmodified":1695886511,
     "wof:name":"Al Khalq",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/063/9/1091920639.geojson
+++ b/data/109/192/063/9/1091920639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030454,
-    "geom:area_square_m":361770498.903353,
+    "geom:area_square_m":361770163.259829,
     "geom:bbox":"44.436355,15.999646,44.698452,16.191481",
     "geom:latitude":16.113902,
     "geom:longitude":44.557842,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.MS",
         "wd:id":"Q4117324"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893014,
-    "wof:geomhash":"5d23ba04132580d165a2687d3bd64b20",
+    "wof:geomhash":"8fd834fed87f30e5aaded0eb6e996fed",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920639,
-    "wof:lastmodified":1690924950,
+    "wof:lastmodified":1695886498,
     "wof:name":"Al Maslub",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/067/3/1091920673.geojson
+++ b/data/109/192/067/3/1091920673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062646,
-    "geom:area_square_m":743824473.703874,
+    "geom:area_square_m":743824291.056126,
     "geom:bbox":"44.26053,16.019804,44.51838,16.377414",
     "geom:latitude":16.21341,
     "geom:longitude":44.386417,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.JA.MM",
         "wd:id":"Q1884259"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893015,
-    "wof:geomhash":"1210834e82e977da94cf7732294ea48f",
+    "wof:geomhash":"5c7af74dbd1ac90f9c425f6da30f5251",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091920673,
-    "wof:lastmodified":1690925008,
+    "wof:lastmodified":1695886511,
     "wof:name":"Al Matammah",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/070/1/1091920701.geojson
+++ b/data/109/192/070/1/1091920701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035536,
-    "geom:area_square_m":421811855.658874,
+    "geom:area_square_m":421811789.260998,
     "geom:bbox":"44.498683,16.18149,44.779682,16.387537",
     "geom:latitude":16.271545,
     "geom:longitude":44.63491,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.MN",
         "wd:id":"Q4704407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893016,
-    "wof:geomhash":"77d7c3bd6518bc68035077dcb866710d",
+    "wof:geomhash":"bdaaa072418c1f29371ee1d49d3f8656",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920701,
-    "wof:lastmodified":1690924932,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Maton",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/071/9/1091920719.geojson
+++ b/data/109/192/071/9/1091920719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011379,
-    "geom:area_square_m":135015016.908357,
+    "geom:area_square_m":135015124.769805,
     "geom:bbox":"44.450678,16.263748,44.596294,16.39916",
     "geom:latitude":16.342701,
     "geom:longitude":44.515966,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.JA.ZA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893017,
-    "wof:geomhash":"44b269bd1877f120a9a1c34d76173951",
+    "wof:geomhash":"8faa909d2f467df3000ee85dfcebaf12",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091920719,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886233,
     "wof:name":"Az Zahir",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/074/9/1091920749.geojson
+++ b/data/109/192/074/9/1091920749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.135115,
-    "geom:area_square_m":1598623397.851413,
+    "geom:area_square_m":1598622856.515185,
     "geom:bbox":"44.144161,16.649343,44.894157,17.064256",
     "geom:latitude":16.893177,
     "geom:longitude":44.517407,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.JA.BA",
         "wd:id":"Q4117229"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893018,
-    "wof:geomhash":"6eb199f69d7c21c2e54fc90de434d1bd",
+    "wof:geomhash":"b9db600bf77316b8a3cef6eb504275e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091920749,
-    "wof:lastmodified":1690924984,
+    "wof:lastmodified":1695886505,
     "wof:name":"Bart Al Anan",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/077/5/1091920775.geojson
+++ b/data/109/192/077/5/1091920775.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.753724,
-    "geom:area_square_m":32619909291.380066,
+    "geom:area_square_m":32619909025.05479,
     "geom:bbox":"44.571608,15.760067,47.001414,17.433535",
     "geom:latitude":16.662421,
     "geom:longitude":45.813119,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.JA.KS",
         "wd:id":"Q4117286"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893019,
-    "wof:geomhash":"d205462148fe5eb812869335b50f2da8",
+    "wof:geomhash":"a197f794154c66e8602ae7973afbc982",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091920775,
-    "wof:lastmodified":1690924930,
+    "wof:lastmodified":1695886494,
     "wof:name":"Khabb wa ash Sha'af",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/081/1/1091920811.geojson
+++ b/data/109/192/081/1/1091920811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03327,
-    "geom:area_square_m":394215487.384053,
+    "geom:area_square_m":394215247.799783,
     "geom:bbox":"44.051953,16.488221,44.402713,16.732472",
     "geom:latitude":16.614527,
     "geom:longitude":44.24781,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.KM",
         "wd:id":"Q4117302"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893020,
-    "wof:geomhash":"385bd2985ce125a449f87e60edea840d",
+    "wof:geomhash":"a64079ca2008cd8ecda30ffe8ebf4ac3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920811,
-    "wof:lastmodified":1690924987,
+    "wof:lastmodified":1695886506,
     "wof:name":"Kharab Al Marashi",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/084/1/1091920841.geojson
+++ b/data/109/192/084/1/1091920841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.085084,
-    "geom:area_square_m":1008003276.204964,
+    "geom:area_square_m":1008003323.466853,
     "geom:bbox":"44.315488,16.462447,44.693784,16.807915",
     "geom:latitude":16.643371,
     "geom:longitude":44.530643,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.JA.RA",
         "wd:id":"Q4117304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893021,
-    "wof:geomhash":"b75f8b5e591ec444ed0bdf2f34c6720e",
+    "wof:geomhash":"76579b3dfa6edd83c70026ed5952a282",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091920841,
-    "wof:lastmodified":1690924931,
+    "wof:lastmodified":1695886494,
     "wof:name":"Rajuzah",
     "wof:parent_id":85681007,
     "wof:placetype":"county",

--- a/data/109/192/085/5/1091920855.geojson
+++ b/data/109/192/085/5/1091920855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.715012,
-    "geom:area_square_m":8482572262.852128,
+    "geom:area_square_m":8482572153.197407,
     "geom:bbox":"51.452549,15.621561,52.707263,16.909973",
     "geom:latitude":16.374331,
     "geom:longitude":52.055731,
@@ -122,9 +122,10 @@
         "hasc:id":"YE.MR.GH",
         "wd:id":"Q4117605"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893022,
-    "wof:geomhash":"e74add2f7a3cecf6b02f694fd04b21de",
+    "wof:geomhash":"6eb86890d4fe20363ecd141811df564a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1091920855,
-    "wof:lastmodified":1690924937,
+    "wof:lastmodified":1695886735,
     "wof:name":"Al Ghaydah",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/088/1/1091920881.geojson
+++ b/data/109/192/088/1/1091920881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.62774,
-    "geom:area_square_m":7474458399.739691,
+    "geom:area_square_m":7474457925.955979,
     "geom:bbox":"50.129217,15.080389,51.156608,16.199178",
     "geom:latitude":15.645295,
     "geom:longitude":50.620138,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MR.MS",
         "wd:id":"Q4118398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893023,
-    "wof:geomhash":"fbb0c30313854b3a7231238a31741aa6",
+    "wof:geomhash":"30fb84a17cf7a56cf198f624ba940d0c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920881,
-    "wof:lastmodified":1690924990,
+    "wof:lastmodified":1695886507,
     "wof:name":"Al Masilah",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/091/3/1091920913.geojson
+++ b/data/109/192/091/3/1091920913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.537435,
-    "geom:area_square_m":18108691874.568901,
+    "geom:area_square_m":18108692245.998268,
     "geom:bbox":"51.066273,16.607375,52.289669,18.999633",
     "geom:latitude":17.705357,
     "geom:longitude":51.811449,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MR.HT",
         "wd:id":"Q4117708"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893024,
-    "wof:geomhash":"a3a64007eddd2bb2f58fefaf9797464c",
+    "wof:geomhash":"42f2d780a81a4b16d086aa93741b9beb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920913,
-    "wof:lastmodified":1690924940,
+    "wof:lastmodified":1695886496,
     "wof:name":"Hat",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/094/7/1091920947.geojson
+++ b/data/109/192/094/7/1091920947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127825,
-    "geom:area_square_m":1513828910.254534,
+    "geom:area_square_m":1513829554.208804,
     "geom:bbox":"52.530218,16.515413,53.109085,16.871566",
     "geom:latitude":16.709738,
     "geom:longitude":52.791106,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.MR.HF",
         "wd:id":"Q4117695"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893025,
-    "wof:geomhash":"1efb2c788dffa927a752e02bf95ebb9c",
+    "wof:geomhash":"9c6bb9b04cfc7bdb7477557acb090085",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091920947,
-    "wof:lastmodified":1690925009,
+    "wof:lastmodified":1695886511,
     "wof:name":"Hawf",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/097/3/1091920973.geojson
+++ b/data/109/192/097/3/1091920973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15575,
-    "geom:area_square_m":1853792227.199828,
+    "geom:area_square_m":1853792864.855153,
     "geom:bbox":"51.617835,15.44625,52.21034,16.007025",
     "geom:latitude":15.72545,
     "geom:longitude":51.892736,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MR.HU",
         "wd:id":"Q4117683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893027,
-    "wof:geomhash":"aebba532f6b79a88800a8a053ab9a328",
+    "wof:geomhash":"f5ce62e20e27f45ca7672128c3e5944f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920973,
-    "wof:lastmodified":1690924950,
+    "wof:lastmodified":1695886498,
     "wof:name":"Huswain",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/099/3/1091920993.geojson
+++ b/data/109/192/099/3/1091920993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.212828,
-    "geom:area_square_m":14377261243.101877,
+    "geom:area_square_m":14377260855.88376,
     "geom:bbox":"50.167971,15.979188,51.80973,17.120403",
     "geom:latitude":16.525048,
     "geom:longitude":50.994832,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MR.MN",
         "wd:id":"Q4117680"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893028,
-    "wof:geomhash":"6cc6e45fd6bf0ffc80655fbdf8e12173",
+    "wof:geomhash":"94ad4d583dbbd95e915d8e19f4681979",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091920993,
-    "wof:lastmodified":1690924948,
+    "wof:lastmodified":1695886498,
     "wof:name":"Man'ar",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/102/5/1091921025.geojson
+++ b/data/109/192/102/5/1091921025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32338,
-    "geom:area_square_m":3847786770.30769,
+    "geom:area_square_m":3847786496.547735,
     "geom:bbox":"50.790271,15.329365,51.839931,16.064",
     "geom:latitude":15.787808,
     "geom:longitude":51.398492,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.MR.QI",
         "wd:id":"Q4117812"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893030,
-    "wof:geomhash":"a072306ecaf21a600240caefac096070",
+    "wof:geomhash":"8bffe5666e5e0e34dac80d6d2dc756ef",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091921025,
-    "wof:lastmodified":1690924920,
+    "wof:lastmodified":1695886492,
     "wof:name":"Qishn",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/105/3/1091921053.geojson
+++ b/data/109/192/105/3/1091921053.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.2461,
-    "geom:area_square_m":2932245091.735033,
+    "geom:area_square_m":2932245610.946125,
     "geom:bbox":"50.907475,15.172916,51.637957,15.895979",
     "geom:latitude":15.50956,
     "geom:longitude":51.2251,
@@ -104,9 +104,10 @@
         "hasc:id":"YE.MR.SA",
         "wd:id":"Q1656398"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893031,
-    "wof:geomhash":"865328b9c024e9213bc0a7c3ef341cd0",
+    "wof:geomhash":"4c24eba024328f5434694290f4f64685",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091921053,
-    "wof:lastmodified":1690924922,
+    "wof:lastmodified":1695886492,
     "wof:name":"Sayhut",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/107/9/1091921079.geojson
+++ b/data/109/192/107/9/1091921079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.688374,
-    "geom:area_square_m":8117762149.226801,
+    "geom:area_square_m":8117761420.287749,
     "geom:bbox":"52.150089,16.795264,53.034915,18.38862",
     "geom:latitude":17.427536,
     "geom:longitude":52.482698,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MR.SH",
         "wd:id":"Q4117616"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893032,
-    "wof:geomhash":"c410b3b1cd121ea00fe387f8162312a2",
+    "wof:geomhash":"3e8ec0d48119ac683b60b057bdbb082f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091921079,
-    "wof:lastmodified":1690924977,
+    "wof:lastmodified":1695886504,
     "wof:name":"Shahan",
     "wof:parent_id":85680995,
     "wof:placetype":"county",

--- a/data/109/192/110/1/1091921101.geojson
+++ b/data/109/192/110/1/1091921101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02059,
-    "geom:area_square_m":245355936.45658,
+    "geom:area_square_m":245355883.267035,
     "geom:bbox":"43.239006,15.409766,43.490066,15.550922",
     "geom:latitude":15.488177,
     "geom:longitude":43.369641,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MW.KH",
         "wd:id":"Q4117341"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893034,
-    "wof:geomhash":"fadb69b28c5e24b21703810fdef0a1c9",
+    "wof:geomhash":"28212146b0b382d04f6a43884a7397cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921101,
-    "wof:lastmodified":1690924967,
+    "wof:lastmodified":1695886502,
     "wof:name":"Al Khabt",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/113/7/1091921137.geojson
+++ b/data/109/192/113/7/1091921137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024307,
-    "geom:area_square_m":289751893.129769,
+    "geom:area_square_m":289752199.036143,
     "geom:bbox":"43.452211,15.271229,43.68079,15.552491",
     "geom:latitude":15.411633,
     "geom:longitude":43.561049,
@@ -149,9 +149,10 @@
         "hasc:id":"YE.MW.MA",
         "wd:id":"Q310622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893035,
-    "wof:geomhash":"0f01ff454320a94331076ba626429889",
+    "wof:geomhash":"b282e1f36c2003f2066eaf2a2c750311",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +162,7 @@
         }
     ],
     "wof:id":1091921137,
-    "wof:lastmodified":1690925019,
+    "wof:lastmodified":1695886513,
     "wof:name":"Al Mahwait",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/116/9/1091921169.geojson
+++ b/data/109/192/116/9/1091921169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001185,
-    "geom:area_square_m":14127186.717422,
+    "geom:area_square_m":14127329.411429,
     "geom:bbox":"43.53052,15.435866,43.563919,15.493854",
     "geom:latitude":15.465422,
     "geom:longitude":43.548899,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.MW.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893036,
-    "wof:geomhash":"931d775181fc47c256e57fed68eaa73b",
+    "wof:geomhash":"eb46f01a764ca3e9f5d51344a761d2e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091921169,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886233,
     "wof:name":"Al Mahwait City",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/118/7/1091921187.geojson
+++ b/data/109/192/118/7/1091921187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028147,
-    "geom:area_square_m":335507364.800949,
+    "geom:area_square_m":335507120.50956,
     "geom:bbox":"43.551403,15.281378,43.769798,15.541222",
     "geom:latitude":15.423506,
     "geom:longitude":43.665325,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MW.RU",
         "wd:id":"Q4117345"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893037,
-    "wof:geomhash":"dba39009faa5b7712a02514a36697b91",
+    "wof:geomhash":"25615962a370d4c85c0857545a5e2093",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921187,
-    "wof:lastmodified":1690924961,
+    "wof:lastmodified":1695886500,
     "wof:name":"Ar Rujum",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/121/3/1091921213.geojson
+++ b/data/109/192/121/3/1091921213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020393,
-    "geom:area_square_m":243042887.230729,
+    "geom:area_square_m":243042894.867052,
     "geom:bbox":"43.650757,15.329997,43.851316,15.569917",
     "geom:latitude":15.457394,
     "geom:longitude":43.765149,
@@ -88,9 +88,10 @@
     "wof:concordances":{
         "hasc:id":"YE.MW.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893038,
-    "wof:geomhash":"df1e4e1ef594d867bba32c7dc9ee7a35",
+    "wof:geomhash":"ba7eac8c646da912044b454671d6c52c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1091921213,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886234,
     "wof:name":"At Tawilah",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/124/3/1091921243.geojson
+++ b/data/109/192/124/3/1091921243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046555,
-    "geom:area_square_m":555446398.693399,
+    "geom:area_square_m":555446399.008961,
     "geom:bbox":"43.386254,15.045284,43.644992,15.420308",
     "geom:latitude":15.229448,
     "geom:longitude":43.504997,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MW.BS",
         "wd:id":"Q4117337"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893039,
-    "wof:geomhash":"8f3fef725d8f971f8315b9da8ce51289",
+    "wof:geomhash":"99f58d5523ac553ed00a955329dfbb2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921243,
-    "wof:lastmodified":1690925013,
+    "wof:lastmodified":1695886511,
     "wof:name":"Bani Sa'd",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/127/5/1091921275.geojson
+++ b/data/109/192/127/5/1091921275.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012381,
-    "geom:area_square_m":147616275.863497,
+    "geom:area_square_m":147616295.991078,
     "geom:bbox":"43.371867,15.272146,43.480776,15.475297",
     "geom:latitude":15.375249,
     "geom:longitude":43.424086,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MW.HU",
         "wd:id":"Q4117243"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893040,
-    "wof:geomhash":"1e9a636dadab598aec1084d117e9f44c",
+    "wof:geomhash":"bd09a51a43a9f26d7e680d8c1fc75e56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091921275,
-    "wof:lastmodified":1690924961,
+    "wof:lastmodified":1695886501,
     "wof:name":"Hufash",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/130/7/1091921307.geojson
+++ b/data/109/192/130/7/1091921307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028512,
-    "geom:area_square_m":340011408.905474,
+    "geom:area_square_m":340011337.695189,
     "geom:bbox":"43.24121,15.19212,43.42143,15.450761",
     "geom:latitude":15.330713,
     "geom:longitude":43.329654,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MW.MI",
         "wd:id":"Q6851806"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893041,
-    "wof:geomhash":"e776f1dbf0bbf05316a2aad4e3dcbacf",
+    "wof:geomhash":"72a5757e4f00b9cc6d7a0cdddeb05162",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921307,
-    "wof:lastmodified":1690924981,
+    "wof:lastmodified":1695886505,
     "wof:name":"Milhan",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/131/5/1091921315.geojson
+++ b/data/109/192/131/5/1091921315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013808,
-    "geom:area_square_m":164540528.846697,
+    "geom:area_square_m":164540406.638622,
     "geom:bbox":"43.771602,15.374936,43.915297,15.561609",
     "geom:latitude":15.481671,
     "geom:longitude":43.850928,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MW.SK",
         "wd:id":"Q4117372"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893042,
-    "wof:geomhash":"158c8674eab150d5b440b93100446089",
+    "wof:geomhash":"1e538ff917a9d4aaf0e7daa62f031982",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921315,
-    "wof:lastmodified":1690924975,
+    "wof:lastmodified":1695886503,
     "wof:name":"Shibam Kawkaban",
     "wof:parent_id":85680965,
     "wof:placetype":"county",

--- a/data/109/192/134/3/1091921343.geojson
+++ b/data/109/192/134/3/1091921343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000496,
-    "geom:area_square_m":5918434.177147,
+    "geom:area_square_m":5918490.607535,
     "geom:bbox":"44.168811,15.324487,44.206672,15.347311",
     "geom:latitude":15.336447,
     "geom:longitude":44.18836,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.WA",
         "wd:id":"Q4117329"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893044,
-    "wof:geomhash":"797667f2440ffd44808b7d79d46bd752",
+    "wof:geomhash":"4457a3c42da82686f964fde0d715837c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921343,
-    "wof:lastmodified":1690924923,
+    "wof:lastmodified":1695886234,
     "wof:name":"Al Wahdah",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/137/7/1091921377.geojson
+++ b/data/109/192/137/7/1091921377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002578,
-    "geom:area_square_m":30751161.499837,
+    "geom:area_square_m":30751312.014506,
     "geom:bbox":"44.178306,15.291572,44.259321,15.336886",
     "geom:latitude":15.314609,
     "geom:longitude":44.215442,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.SA",
         "wd:id":"Q4117333"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893045,
-    "wof:geomhash":"8194cd3ed9532f6d01d22435a7508a4c",
+    "wof:geomhash":"eaec888f7923d133c55832cad5aa4a28",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921377,
-    "wof:lastmodified":1690924980,
+    "wof:lastmodified":1695886234,
     "wof:name":"As Sabain",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/140/5/1091921405.geojson
+++ b/data/109/192/140/5/1091921405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000601,
-    "geom:area_square_m":7166854.568609,
+    "geom:area_square_m":7166949.40972,
     "geom:bbox":"44.202298,15.332463,44.260649,15.35239",
     "geom:latitude":15.340334,
     "geom:longitude":44.230895,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.AS",
         "wd:id":"Q4117279"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893046,
-    "wof:geomhash":"5819d84bcdf284493784ad7c9211af20",
+    "wof:geomhash":"88471fb76fa18d9de72dccaec9c87a73",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921405,
-    "wof:lastmodified":1690925020,
+    "wof:lastmodified":1695886234,
     "wof:name":"Assafi'yah",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/143/7/1091921437.geojson
+++ b/data/109/192/143/7/1091921437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000209,
-    "geom:area_square_m":2489052.287036,
+    "geom:area_square_m":2488962.00422,
     "geom:bbox":"44.191428,15.34302,44.20771,15.360919",
     "geom:latitude":15.35204,
     "geom:longitude":44.199873,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.TA",
         "wd:id":"Q4117257"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893047,
-    "wof:geomhash":"8b1893940cd3d527d1ff47e2a0e2f8f9",
+    "wof:geomhash":"38cde56cc3500ce8a1d60f05c7b67b7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921437,
-    "wof:lastmodified":1690924963,
+    "wof:lastmodified":1695886234,
     "wof:name":"At Tahrir",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/145/9/1091921459.geojson
+++ b/data/109/192/145/9/1091921459.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001725,
-    "geom:area_square_m":20564103.198622,
+    "geom:area_square_m":20564014.071967,
     "geom:bbox":"44.173318,15.359092,44.217161,15.421359",
     "geom:latitude":15.391285,
     "geom:longitude":44.194895,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.AT",
         "wd:id":"Q4117271"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893048,
-    "wof:geomhash":"1c09255109326ffb93b6a5079f1c5026",
+    "wof:geomhash":"d2473157d787992b71553a07193b7438",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921459,
-    "wof:lastmodified":1690924959,
+    "wof:lastmodified":1695886234,
     "wof:name":"Ath'thaorah",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/149/1/1091921491.geojson
+++ b/data/109/192/149/1/1091921491.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000706,
-    "geom:area_square_m":8412367.015907,
+    "geom:area_square_m":8412369.060158,
     "geom:bbox":"44.219102,15.343572,44.260957,15.366061",
     "geom:latitude":15.353373,
     "geom:longitude":44.237451,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.AZ",
         "wd:id":"Q4117188"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893049,
-    "wof:geomhash":"fe8f0ed2b7b067e317f3f46dee89bd19",
+    "wof:geomhash":"f3c579364cf5b5946fdb76dfe5628c3d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921491,
-    "wof:lastmodified":1690925021,
+    "wof:lastmodified":1695886234,
     "wof:name":"Az'zal",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/152/3/1091921523.geojson
+++ b/data/109/192/152/3/1091921523.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022549,
-    "geom:area_square_m":268664321.947014,
+    "geom:area_square_m":268664536.994043,
     "geom:bbox":"44.120851,15.397943,44.401989,15.611423",
     "geom:latitude":15.511994,
     "geom:longitude":44.254066,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.BH",
         "wd:id":"Q4117305"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893050,
-    "wof:geomhash":"107d31ebf011737d9a9c50443bf5d4df",
+    "wof:geomhash":"230499e212b27608a2e8fd50a33be6c0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921523,
-    "wof:lastmodified":1690924980,
+    "wof:lastmodified":1695886234,
     "wof:name":"Bani Al Harith",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/155/1/1091921551.geojson
+++ b/data/109/192/155/1/1091921551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002341,
-    "geom:area_square_m":27909172.651204,
+    "geom:area_square_m":27909092.485274,
     "geom:bbox":"44.138604,15.338094,44.19424,15.402542",
     "geom:latitude":15.367749,
     "geom:longitude":44.163621,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.MA",
         "wd:id":"Q4117338"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893051,
-    "wof:geomhash":"94f6becba7dc5280e047865ccdd1939f",
+    "wof:geomhash":"70d8f271c890f5486db2f7c6813a505a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921551,
-    "wof:lastmodified":1690924979,
+    "wof:lastmodified":1695886234,
     "wof:name":"Ma'ain",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/156/5/1091921565.geojson
+++ b/data/109/192/156/5/1091921565.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000132,
-    "geom:area_square_m":1577318.708671,
+    "geom:area_square_m":1577311.971769,
     "geom:bbox":"44.205605,15.349238,44.21955,15.361913",
     "geom:latitude":15.355805,
     "geom:longitude":44.212677,
@@ -99,9 +99,10 @@
         "hasc:id":"YE.SA.OC",
         "wd:id":"Q1650596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893052,
-    "wof:geomhash":"52bf9dc05dc73241d935592a325cd76a",
+    "wof:geomhash":"83e1b39c619e25aff1aa6264e67e408f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -117,7 +118,7 @@
         }
     ],
     "wof:id":1091921565,
-    "wof:lastmodified":1690924925,
+    "wof:lastmodified":1695886234,
     "wof:name":"Old City",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/158/5/1091921585.geojson
+++ b/data/109/192/158/5/1091921585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001305,
-    "geom:area_square_m":15557865.300485,
+    "geom:area_square_m":15557920.173291,
     "geom:bbox":"44.206057,15.359654,44.242092,15.410869",
     "geom:latitude":15.383176,
     "geom:longitude":44.223573,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.SA.SH",
         "wd:id":"Q4117252"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893054,
-    "wof:geomhash":"52eec1c9c04bd889505f55ed1aaaece6",
+    "wof:geomhash":"81e24e1db2f4c9eabcb2a1e8596a9518",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -114,7 +115,7 @@
         }
     ],
     "wof:id":1091921585,
-    "wof:lastmodified":1690924924,
+    "wof:lastmodified":1695886235,
     "wof:name":"Shu'aub",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/161/9/1091921619.geojson
+++ b/data/109/192/161/9/1091921619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054938,
-    "geom:area_square_m":651723545.87862,
+    "geom:area_square_m":651723545.878561,
     "geom:bbox":"43.6325423117,16.0938226428,43.9422922235,16.5583807296",
     "geom:latitude":16.385269,
     "geom:longitude":43.807649,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.AS",
         "wd:id":"Q4703500"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893055,
-    "wof:geomhash":"21f25df40d804c4a3bac64904e909690",
+    "wof:geomhash":"0a6acaabb8539eddd4b526c951cfa5d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921619,
-    "wof:lastmodified":1566660245,
+    "wof:lastmodified":1695886492,
     "wof:name":"Al Ashah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/164/9/1091921649.geojson
+++ b/data/109/192/164/9/1091921649.geojson
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.MD",
         "wd:id":"Q4117467"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893056,
-    "wof:geomhash":"03034975e4edc7073f58939c89122a0b",
+    "wof:geomhash":"f586d670b506e7ea93f2083bf277a674",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921649,
-    "wof:lastmodified":1566660274,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Madan",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/167/7/1091921677.geojson
+++ b/data/109/192/167/7/1091921677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041837,
-    "geom:area_square_m":496540112.195829,
+    "geom:area_square_m":496540112.195793,
     "geom:bbox":"43.5164403405,16.10392641,43.8393002945,16.4467881802",
     "geom:latitude":16.297082,
     "geom:longitude":43.684502,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.QA",
         "wd:id":"Q4117577"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893057,
-    "wof:geomhash":"a889d8505078ee30fbe518336e67ecfe",
+    "wof:geomhash":"edd1b5f1f1665ad03aacf427b560defe",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921677,
-    "wof:lastmodified":1566660247,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Qaflah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/170/9/1091921709.geojson
+++ b/data/109/192/170/9/1091921709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009782,
-    "geom:area_square_m":116453462.055456,
+    "geom:area_square_m":116453437.427079,
     "geom:bbox":"43.727599,15.62636,43.989434,15.734233",
     "geom:latitude":15.679519,
     "geom:longitude":43.859279,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.AM",
         "wd:id":"Q1650593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893058,
-    "wof:geomhash":"a91eec1ed34dd6524dc673de77808bdc",
+    "wof:geomhash":"0daff646887eaf6f7e8668e9fb979c61",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921709,
-    "wof:lastmodified":1690925013,
+    "wof:lastmodified":1695886511,
     "wof:name":"Amran",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/174/5/1091921745.geojson
+++ b/data/109/192/174/5/1091921745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013315,
-    "geom:area_square_m":158418693.872681,
+    "geom:area_square_m":158418693.872666,
     "geom:bbox":"43.7085136449,15.741235012,43.8451982652,15.8839149501",
     "geom:latitude":15.810413,
     "geom:longitude":43.76838,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.SA",
         "wd:id":"Q4117539"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893059,
-    "wof:geomhash":"4fbed4ed7419f5ca48fdfb885a75b10d",
+    "wof:geomhash":"eb4ec8294dbc2cf9da252944ec522fe8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921745,
-    "wof:lastmodified":1566660263,
+    "wof:lastmodified":1695886500,
     "wof:name":"As Sawd",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/177/9/1091921779.geojson
+++ b/data/109/192/177/9/1091921779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014843,
-    "geom:area_square_m":176471913.621131,
+    "geom:area_square_m":176471913.621146,
     "geom:bbox":"43.7038922403,15.8784437641,43.8450553569,16.056298143",
     "geom:latitude":15.952378,
     "geom:longitude":43.770771,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.SU",
         "wd:id":"Q4117524"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893060,
-    "wof:geomhash":"66d78796c4388f777077faa10f9d3002",
+    "wof:geomhash":"261b33ac6aac1ef012dfa8d3a7104e39",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921779,
-    "wof:lastmodified":1566660291,
+    "wof:lastmodified":1695886512,
     "wof:name":"As Sudah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/181/3/1091921813.geojson
+++ b/data/109/192/181/3/1091921813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.027982,
-    "geom:area_square_m":332368842.640994,
+    "geom:area_square_m":332368842.640995,
     "geom:bbox":"43.8427237935,16.0465362527,44.0804355792,16.2052935672",
     "geom:latitude":16.135241,
     "geom:longitude":43.970936,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.BS",
         "wd:id":"Q4117563"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893061,
-    "wof:geomhash":"0fc3da8f09b57940596b7fcd0ede7fb6",
+    "wof:geomhash":"a777c03bc08f765443527c67ae9a33e6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921813,
-    "wof:lastmodified":1566660268,
+    "wof:lastmodified":1695886502,
     "wof:name":"Bani Suraim",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/183/3/1091921833.geojson
+++ b/data/109/192/183/3/1091921833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029123,
-    "geom:area_square_m":346121907.341719,
+    "geom:area_square_m":346121907.341731,
     "geom:bbox":"44.0430550084,15.9010395312,44.2601163722,16.152707434",
     "geom:latitude":16.024772,
     "geom:longitude":44.126931,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.DB",
         "wd:id":"Q4117514"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893062,
-    "wof:geomhash":"e66a79c6880899ed07c08bdc7d2b2990",
+    "wof:geomhash":"2c00e542213d0bb4edb120858924cf97",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921833,
-    "wof:lastmodified":1566660291,
+    "wof:lastmodified":1695886512,
     "wof:name":"Dhi Bin",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/186/1/1091921861.geojson
+++ b/data/109/192/186/1/1091921861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016265,
-    "geom:area_square_m":193281403.701158,
+    "geom:area_square_m":193281403.701169,
     "geom:bbox":"43.6559471853,15.9425391988,43.8104188729,16.1306262284",
     "geom:latitude":16.054658,
     "geom:longitude":43.726181,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.HZ",
         "wd:id":"Q4117558"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893063,
-    "wof:geomhash":"fc035d88d638e9b35a30d75087a8b07d",
+    "wof:geomhash":"88b59cb3a2cd2a88f1282ea79046a982",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921861,
-    "wof:lastmodified":1566660267,
+    "wof:lastmodified":1695886501,
     "wof:name":"Habur Zulaymah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/189/1/1091921891.geojson
+++ b/data/109/192/189/1/1091921891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230248,
-    "geom:area_square_m":2730657596.796651,
+    "geom:area_square_m":2730657596.796661,
     "geom:bbox":"43.5093395532,16.0288125517,44.3495748766,16.6916341706",
     "geom:latitude":16.440061,
     "geom:longitude":43.984992,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.AM.HS",
         "wd:id":"Q4117617"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893064,
-    "wof:geomhash":"6d60d30e4758742538c91eeafad1d833",
+    "wof:geomhash":"9de6aa8fff654a9b9356806b074e24cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091921891,
-    "wof:lastmodified":1566660265,
+    "wof:lastmodified":1695886500,
     "wof:name":"Harf Sufyan",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/192/3/1091921923.geojson
+++ b/data/109/192/192/3/1091921923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031375,
-    "geom:area_square_m":372404470.17498,
+    "geom:area_square_m":372404470.174883,
     "geom:bbox":"43.866831697,16.194674883,44.0905222027,16.3783027427",
     "geom:latitude":16.277289,
     "geom:longitude":43.979859,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.HU",
         "wd:id":"Q4117418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893065,
-    "wof:geomhash":"1847198ee14db3d62ac77e880f41b7f3",
+    "wof:geomhash":"2121417d4e01c0b67712a9294e2d770c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091921923,
-    "wof:lastmodified":1566660245,
+    "wof:lastmodified":1695886492,
     "wof:name":"Huth",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/195/3/1091921953.geojson
+++ b/data/109/192/195/3/1091921953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019755,
-    "geom:area_square_m":235172643.876227,
+    "geom:area_square_m":235172643.876264,
     "geom:bbox":"43.8234710489,15.5591672462,44.0834744424,15.9508726754",
     "geom:latitude":15.692208,
     "geom:longitude":43.967425,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.IS",
         "wd:id":"Q4117525"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893066,
-    "wof:geomhash":"a1d4dfc80f1d5813b1ef913b445e2670",
+    "wof:geomhash":"d3aefcb5e891bbe48ebce846af394a6a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921953,
-    "wof:lastmodified":1566660245,
+    "wof:lastmodified":1695886492,
     "wof:name":"Iyal Surayh",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/196/5/1091921965.geojson
+++ b/data/109/192/196/5/1091921965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040651,
-    "geom:area_square_m":483739056.295724,
+    "geom:area_square_m":483739056.295693,
     "geom:bbox":"43.7571004211,15.6266579192,44.0474889382,15.9168306286",
     "geom:latitude":15.767336,
     "geom:longitude":43.885987,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.JI",
         "wd:id":"Q4117537"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893067,
-    "wof:geomhash":"18ceef0d143862da502f60ddc6beec12",
+    "wof:geomhash":"e75dadf417e7e615473a0265cdff4dd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921965,
-    "wof:lastmodified":1566660271,
+    "wof:lastmodified":1695886503,
     "wof:name":"Jabal Iyal Yazid",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/199/3/1091921993.geojson
+++ b/data/109/192/199/3/1091921993.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035569,
-    "geom:area_square_m":422763648.89194,
+    "geom:area_square_m":422763648.892025,
     "geom:bbox":"43.7934459256,15.8723956449,44.0696457379,16.1202021908",
     "geom:latitude":16.005319,
     "geom:longitude":43.922489,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.KM",
         "wd:id":"Q3196049"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893069,
-    "wof:geomhash":"318ca792c0e5ae98695c58461124dea6",
+    "wof:geomhash":"da526b64badb5ace13f4940b5c583361",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091921993,
-    "wof:lastmodified":1566660275,
+    "wof:lastmodified":1695886505,
     "wof:name":"Khamir",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/202/5/1091922025.geojson
+++ b/data/109/192/202/5/1091922025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02228,
-    "geom:area_square_m":265017850.35709,
+    "geom:area_square_m":265017769.486033,
     "geom:bbox":"43.981553,15.73002,44.179845,15.963304",
     "geom:latitude":15.850487,
     "geom:longitude":44.085397,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.KF",
         "wd:id":"Q4117448"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893070,
-    "wof:geomhash":"c3ac5f70d738583943cbf407f95cd974",
+    "wof:geomhash":"275669a00a5c5190c655d4a6993cf088",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922025,
-    "wof:lastmodified":1690924952,
+    "wof:lastmodified":1695886499,
     "wof:name":"Kharif",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/205/9/1091922059.geojson
+++ b/data/109/192/205/9/1091922059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01112,
-    "geom:area_square_m":132436796.833415,
+    "geom:area_square_m":132436796.833404,
     "geom:bbox":"43.6344444936,15.5310390338,43.7505094506,15.6666994498",
     "geom:latitude":15.599025,
     "geom:longitude":43.694481,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.MW",
         "wd:id":"Q4117443"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893071,
-    "wof:geomhash":"7669896539be65e7105b7bdd273a4a80",
+    "wof:geomhash":"b3f6aca36acbeedc009bbb04cad1bd48",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922059,
-    "wof:lastmodified":1566660261,
+    "wof:lastmodified":1695886499,
     "wof:name":"Maswar",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/209/1/1091922091.geojson
+++ b/data/109/192/209/1/1091922091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016925,
-    "geom:area_square_m":201383840.45746,
+    "geom:area_square_m":201383840.457462,
     "geom:bbox":"43.9296900569,15.641275985,44.107316411,15.9293316441",
     "geom:latitude":15.786849,
     "geom:longitude":44.023804,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.AM.RA",
         "wd:id":"Q4117431"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893072,
-    "wof:geomhash":"85ecf62b47a208af5204d305b13c622c",
+    "wof:geomhash":"45c91edc238ae8ed674373330355c6bf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091922091,
-    "wof:lastmodified":1566660283,
+    "wof:lastmodified":1695886508,
     "wof:name":"Raydah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/210/5/1091922105.geojson
+++ b/data/109/192/210/5/1091922105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014625,
-    "geom:area_square_m":173677070.76797,
+    "geom:area_square_m":173677070.767986,
     "geom:bbox":"43.6314226501,16.0925069538,43.766764504,16.2808101437",
     "geom:latitude":16.181348,
     "geom:longitude":43.702351,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.SH",
         "wd:id":"Q665937"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893073,
-    "wof:geomhash":"d6d2c22b01780e602dd28305c703d9db",
+    "wof:geomhash":"d6017cf85b085196f6f706b113138412",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922105,
-    "wof:lastmodified":1566660252,
+    "wof:lastmodified":1695886495,
     "wof:name":"Shaharah",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/213/5/1091922135.geojson
+++ b/data/109/192/213/5/1091922135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012791,
-    "geom:area_square_m":151982545.546015,
+    "geom:area_square_m":151982545.546038,
     "geom:bbox":"43.5677242524,15.9369123103,43.6737678907,16.1861919961",
     "geom:latitude":16.075547,
     "geom:longitude":43.616102,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.AM.SR",
         "wd:id":"Q4117464"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893074,
-    "wof:geomhash":"f719d9e2189a9f4e034b45bf4a158966",
+    "wof:geomhash":"c03c51d4c21da44ec8b7eb93aa268dda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922135,
-    "wof:lastmodified":1566660282,
+    "wof:lastmodified":1695886508,
     "wof:name":"Suwayr",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/217/1/1091922171.geojson
+++ b/data/109/192/217/1/1091922171.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014776,
-    "geom:area_square_m":175986813.602184,
+    "geom:area_square_m":175986813.602198,
     "geom:bbox":"43.7346288465,15.532304844,43.9175911494,15.6676125494",
     "geom:latitude":15.592905,
     "geom:longitude":43.823822,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.AM.TH",
         "wd:id":"Q4117440"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893075,
-    "wof:geomhash":"e5382d1d6d76875b1f4f4562c7c7c6d3",
+    "wof:geomhash":"f3c0916291171070b92f0621b469e382",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922171,
-    "wof:lastmodified":1566660252,
+    "wof:lastmodified":1695886495,
     "wof:name":"Thula",
     "wof:parent_id":85680977,
     "wof:placetype":"county",

--- a/data/109/192/219/9/1091922199.geojson
+++ b/data/109/192/219/9/1091922199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136433,
-    "geom:area_square_m":1630993377.68534,
+    "geom:area_square_m":1630993229.809708,
     "geom:bbox":"44.301172,14.597608,44.836852,15.018695",
     "geom:latitude":14.80798,
     "geom:longitude":44.559936,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DH.HA",
         "wd:id":"Q1650858"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893076,
-    "wof:geomhash":"aec493b5244e7d5429990dec1991e10a",
+    "wof:geomhash":"7ce5e5cb8cd91fa800399a53bfdf55cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091922199,
-    "wof:lastmodified":1690924933,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Hada",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/223/1/1091922231.geojson
+++ b/data/109/192/223/1/1091922231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030009,
-    "geom:area_square_m":359035672.02786,
+    "geom:area_square_m":359035905.128761,
     "geom:bbox":"43.971838,14.557043,44.260686,14.749567",
     "geom:latitude":14.630825,
     "geom:longitude":44.128159,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DH.MN",
         "wd:id":"Q4117307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893077,
-    "wof:geomhash":"dc43e5142a025561dc4eb7f8bf4c1ab0",
+    "wof:geomhash":"7ecda5de66a845198ad3de223e525e62",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091922231,
-    "wof:lastmodified":1690924986,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al Manar",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/224/9/1091922249.geojson
+++ b/data/109/192/224/9/1091922249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.068191,
-    "geom:area_square_m":816560607.571234,
+    "geom:area_square_m":816560503.112564,
     "geom:bbox":"44.157946,14.270194,44.625126,14.598138",
     "geom:latitude":14.438568,
     "geom:longitude":44.397928,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.DH.AN",
         "wd:id":"Q4117317"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893078,
-    "wof:geomhash":"59318a9b0d5320ea3b4ae520dd401acd",
+    "wof:geomhash":"44c8244d03c57ac1939652cc2a5c48f2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922249,
-    "wof:lastmodified":1690924986,
+    "wof:lastmodified":1695886506,
     "wof:name":"Anss",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/227/7/1091922277.geojson
+++ b/data/109/192/227/7/1091922277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084391,
-    "geom:area_square_m":1008723734.772973,
+    "geom:area_square_m":1008723313.532648,
     "geom:bbox":"43.901492,14.654652,44.329883,15.002699",
     "geom:latitude":14.835196,
     "geom:longitude":44.106154,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DH.DA",
         "wd:id":"Q4118402"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893079,
-    "wof:geomhash":"7d06636bae8bb701e45726ecf9353b13",
+    "wof:geomhash":"e91559f396f782a5932e6279d6ef52bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091922277,
-    "wof:lastmodified":1690924927,
+    "wof:lastmodified":1695886493,
     "wof:name":"Dawran Aness",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/230/3/1091922303.geojson
+++ b/data/109/192/230/3/1091922303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020197,
-    "geom:area_square_m":241676922.825106,
+    "geom:area_square_m":241677002.933206,
     "geom:bbox":"44.310349,14.517027,44.496074,14.69915",
     "geom:latitude":14.597335,
     "geom:longitude":44.386969,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.DH.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893080,
-    "wof:geomhash":"f3791c79c655f594362cdd597ae6099f",
+    "wof:geomhash":"8ad2268b437215b8a9c0af565cbc3622",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091922303,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886234,
     "wof:name":"Dhamar City",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/233/7/1091922337.geojson
+++ b/data/109/192/233/7/1091922337.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037086,
-    "geom:area_square_m":443491657.772396,
+    "geom:area_square_m":443491432.665972,
     "geom:bbox":"43.755931,14.597243,44.057262,14.863046",
     "geom:latitude":14.738588,
     "geom:longitude":43.91408,
@@ -93,9 +93,10 @@
         "hasc:id":"YE.DH.JS",
         "wd:id":"Q6109810"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893081,
-    "wof:geomhash":"34244bf8a820fe17bab7fcf11e889b86",
+    "wof:geomhash":"25765c6c1bb37d768a36e69f1409147f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091922337,
-    "wof:lastmodified":1690924953,
+    "wof:lastmodified":1695886499,
     "wof:name":"Jabal Ash sharq",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/237/1/1091922371.geojson
+++ b/data/109/192/237/1/1091922371.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030838,
-    "geom:area_square_m":368749293.897488,
+    "geom:area_square_m":368749352.95857,
     "geom:bbox":"44.226333,14.539768,44.400997,14.929425",
     "geom:latitude":14.751335,
     "geom:longitude":44.297772,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.DH.JA",
         "wd:id":"Q4117825"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893082,
-    "wof:geomhash":"6cec0af2cf9d575da7e7b3ccb8236b87",
+    "wof:geomhash":"7fb805eb0f1731bf975b8046c12511d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922371,
-    "wof:lastmodified":1690925006,
+    "wof:lastmodified":1695886510,
     "wof:name":"Jahran",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/240/3/1091922403.geojson
+++ b/data/109/192/240/3/1091922403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020539,
-    "geom:area_square_m":245916343.526396,
+    "geom:area_square_m":245916126.935724,
     "geom:bbox":"44.052118,14.362008,44.199792,14.563897",
     "geom:latitude":14.467799,
     "geom:longitude":44.128651,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.DH.MA",
         "wd:id":"Q4117191"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893083,
-    "wof:geomhash":"1aabdc8097ee6502a32a7457116e07db",
+    "wof:geomhash":"b419b43b1cf895744bf849bccfc2921a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922403,
-    "wof:lastmodified":1690924988,
+    "wof:lastmodified":1695886506,
     "wof:name":"Maghirib Ans",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/243/7/1091922437.geojson
+++ b/data/109/192/243/7/1091922437.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051793,
-    "geom:area_square_m":619967099.00626,
+    "geom:area_square_m":619967216.18585,
     "geom:bbox":"44.478816,14.363216,44.740522,14.666364",
     "geom:latitude":14.521924,
     "geom:longitude":44.613928,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DH.MF",
         "wd:id":"Q3302970"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893084,
-    "wof:geomhash":"5359884957d0b6060b7f269739453ec5",
+    "wof:geomhash":"9a37f6952e4e75e5865496433038d203",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091922437,
-    "wof:lastmodified":1690924936,
+    "wof:lastmodified":1695886495,
     "wof:name":"Mayfa'at Anss",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/246/7/1091922467.geojson
+++ b/data/109/192/246/7/1091922467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037784,
-    "geom:area_square_m":452356547.981489,
+    "geom:area_square_m":452356588.473665,
     "geom:bbox":"43.807109,14.349588,44.086526,14.601829",
     "geom:latitude":14.482497,
     "geom:longitude":43.9538,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.DH.UT",
         "wd:id":"Q4117268"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893085,
-    "wof:geomhash":"d50cd252d08444bb38b61a611cbb1bf5",
+    "wof:geomhash":"69d8c9a45d4890137e4e177b5edc0bc4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091922467,
-    "wof:lastmodified":1690924984,
+    "wof:lastmodified":1695886505,
     "wof:name":"Utmah",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/249/9/1091922499.geojson
+++ b/data/109/192/249/9/1091922499.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049577,
-    "geom:area_square_m":593927812.236623,
+    "geom:area_square_m":593927574.844518,
     "geom:bbox":"43.645458,14.189667,43.944158,14.478988",
     "geom:latitude":14.341015,
     "geom:longitude":43.807395,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.DH.WA",
         "wd:id":"Q4117263"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893086,
-    "wof:geomhash":"ea9d6ff633b44a28595b30e71eced2ae",
+    "wof:geomhash":"aebca7c85392ddff6a047779a57bab2e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922499,
-    "wof:lastmodified":1690924988,
+    "wof:lastmodified":1695886506,
     "wof:name":"Wusab Al Ali",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/251/9/1091922519.geojson
+++ b/data/109/192/251/9/1091922519.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.06996,
-    "geom:area_square_m":838472548.353494,
+    "geom:area_square_m":838472802.862704,
     "geom:bbox":"43.476472,14.067596,43.790308,14.437007",
     "geom:latitude":14.245286,
     "geom:longitude":43.634575,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.DH.WS",
         "wd:id":"Q4117298"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893088,
-    "wof:geomhash":"de59aef2add0451b4e59f1e47d6dfed0",
+    "wof:geomhash":"79858837bf27ffeeb0462b20093c3adc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922519,
-    "wof:lastmodified":1690924949,
+    "wof:lastmodified":1695886498,
     "wof:name":"Wusab As Safil",
     "wof:parent_id":85680969,
     "wof:placetype":"county",

--- a/data/109/192/254/9/1091922549.geojson
+++ b/data/109/192/254/9/1091922549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137488,
-    "geom:area_square_m":1641833927.192374,
+    "geom:area_square_m":1641833927.192487,
     "geom:bbox":"49.787298571,14.808694839,50.2444351666,15.3818317117",
     "geom:latitude":15.03879,
     "geom:longitude":49.975438,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.DI",
         "wd:id":"Q4117698"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893089,
-    "wof:geomhash":"d35d46d9b547c9b7fa731ae17aa76c86",
+    "wof:geomhash":"45c6a834138f5d37e8bbf167afcaf997",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922549,
-    "wof:lastmodified":1566660286,
+    "wof:lastmodified":1695886509,
     "wof:name":"Ad Dis",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/258/5/1091922585.geojson
+++ b/data/109/192/258/5/1091922585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.209565,
-    "geom:area_square_m":2503021701.598604,
+    "geom:area_square_m":2503021701.598251,
     "geom:bbox":"47.5604120387,14.7349567989,48.2337607762,15.2944796313",
     "geom:latitude":14.999014,
     "geom:longitude":47.910052,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.DH",
         "wd:id":"Q4117682"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893090,
-    "wof:geomhash":"d46e33771a08c42c78e479feb0ff1bc6",
+    "wof:geomhash":"02ff23855ee8946a06e1cbd2d523daa7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922585,
-    "wof:lastmodified":1566660259,
+    "wof:lastmodified":1695886498,
     "wof:name":"Adh Dhlia'ah",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/261/7/1091922617.geojson
+++ b/data/109/192/261/7/1091922617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.629746,
-    "geom:area_square_m":7489532188.260366,
+    "geom:area_square_m":7489532188.260374,
     "geom:bbox":"46.3118615124,15.6084954819,48.1516028033,16.2207892465",
     "geom:latitude":15.88552,
     "geom:longitude":47.221659,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.AB",
         "wd:id":"Q4117641"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893091,
-    "wof:geomhash":"30e5803453e7a575d7998a1dd2ef8d01",
+    "wof:geomhash":"cdd8ddce4bc399188dedfb3fc6ddd872",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922617,
-    "wof:lastmodified":1566660256,
+    "wof:lastmodified":1695886497,
     "wof:name":"Al Abr",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/264/1/1091922641.geojson
+++ b/data/109/192/264/1/1091922641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.159845,
-    "geom:area_square_m":1911711685.173046,
+    "geom:area_square_m":1911711891.884993,
     "geom:bbox":"48.531129,14.487353,49.303905,14.970259",
     "geom:latitude":14.711423,
     "geom:longitude":48.865661,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HA.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893092,
-    "wof:geomhash":"22a06776781b5f4792d70a8acbf7c239",
+    "wof:geomhash":"5130f6745a06a1434ef0ed44c947377d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091922641,
-    "wof:lastmodified":1636497423,
+    "wof:lastmodified":1695886735,
     "wof:name":"Al Mukalla",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/266/5/1091922665.geojson
+++ b/data/109/192/266/5/1091922665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026053,
-    "geom:area_square_m":311790318.852209,
+    "geom:area_square_m":311790445.920236,
     "geom:bbox":"48.988649,14.409022,49.390678,14.67317",
     "geom:latitude":14.566547,
     "geom:longitude":49.156797,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HA.MC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893093,
-    "wof:geomhash":"710602ceb0249b9f1f990141de3a8a9b",
+    "wof:geomhash":"30f43864eba2439f2f94f91e23508272",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091922665,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Al Mukalla City",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/269/7/1091922697.geojson
+++ b/data/109/192/269/7/1091922697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.435265,
-    "geom:area_square_m":28720376055.278641,
+    "geom:area_square_m":28720376055.278561,
     "geom:bbox":"48.1481787302,16.1760828953,49.7329208603,18.6819045445",
     "geom:latitude":17.478329,
     "geom:longitude":49.046459,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.QF",
         "wd:id":"Q4117689"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893094,
-    "wof:geomhash":"c3221613c1b2021630810e4c936a4019",
+    "wof:geomhash":"a7d642ab6dfe53e4a10dbb32078f63fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922697,
-    "wof:lastmodified":1566660261,
+    "wof:lastmodified":1695886499,
     "wof:name":"Al Qaf",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/273/3/1091922733.geojson
+++ b/data/109/192/273/3/1091922733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.264182,
-    "geom:area_square_m":3140508377.730143,
+    "geom:area_square_m":3140508377.729997,
     "geom:bbox":"47.8353025688,15.6124551501,48.5933414561,16.2351542274",
     "geom:latitude":15.974517,
     "geom:longitude":48.308262,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.QT",
         "wd:id":"Q4117526"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893096,
-    "wof:geomhash":"ae634b14bdedf976d9278581312a881e",
+    "wof:geomhash":"62f4780abc4ac9190f09d3e443991b5f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922733,
-    "wof:lastmodified":1566660250,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Qatn",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/276/5/1091922765.geojson
+++ b/data/109/192/276/5/1091922765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.092232,
-    "geom:area_square_m":1099835240.619362,
+    "geom:area_square_m":1099835240.619347,
     "geom:bbox":"47.7152911006,15.1499173864,48.1430410775,15.5454753181",
     "geom:latitude":15.338792,
     "geom:longitude":47.925493,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.AM",
         "wd:id":"Q4117560"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893097,
-    "wof:geomhash":"ed1b1d7c2234ddbb4c16ce951981006d",
+    "wof:geomhash":"45cb8f4ced7ec2b5d25acd6771f97595",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091922765,
-    "wof:lastmodified":1566660280,
+    "wof:lastmodified":1695886507,
     "wof:name":"Amd",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/278/1/1091922781.geojson
+++ b/data/109/192/278/1/1091922781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295598,
-    "geom:area_square_m":3526969529.655959,
+    "geom:area_square_m":3526969529.655758,
     "geom:bbox":"49.8542431383,14.8939775878,50.7750411295,15.473630684",
     "geom:latitude":15.216935,
     "geom:longitude":50.327536,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.RQ",
         "wd:id":"Q4117638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893098,
-    "wof:geomhash":"4d8f3ed78ccf9f7d04954c4e3331f34f",
+    "wof:geomhash":"b517d247ea83a4a8f6fafd046bc690cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922781,
-    "wof:lastmodified":1566660278,
+    "wof:lastmodified":1695886506,
     "wof:name":"Ar Raydah Wa Qusayar",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/280/7/1091922807.geojson
+++ b/data/109/192/280/7/1091922807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.035349,
-    "geom:area_square_m":12301966689.844572,
+    "geom:area_square_m":12301966689.844574,
     "geom:bbox":"49.0684361263,15.3522462702,50.2701036458,16.6427088305",
     "geom:latitude":16.067681,
     "geom:longitude":49.758385,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.SM",
         "wd:id":"Q4117602"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893099,
-    "wof:geomhash":"38be9c3d947821d300fd0bda01db59b1",
+    "wof:geomhash":"e1d3f2bc41a0a4646a4be562d92f1738",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922807,
-    "wof:lastmodified":1566660249,
+    "wof:lastmodified":1695886494,
     "wof:name":"As Sawm",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/283/7/1091922837.geojson
+++ b/data/109/192/283/7/1091922837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.237693,
-    "geom:area_square_m":2838730999.120766,
+    "geom:area_square_m":2838731110.06337,
     "geom:bbox":"49.25258,14.683415,49.853278,15.271207",
     "geom:latitude":15.017224,
     "geom:longitude":49.575073,
@@ -119,9 +119,10 @@
         "hasc:id":"YE.HA.SH",
         "wd:id":"Q4117645"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893100,
-    "wof:geomhash":"350e056b2a07ad836e8090ab3789a4d0",
+    "wof:geomhash":"d490c9366b94ce9100addef6cfd56ab2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1091922837,
-    "wof:lastmodified":1636497423,
+    "wof:lastmodified":1695886735,
     "wof:name":"Ash Shihr",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/285/7/1091922857.geojson
+++ b/data/109/192/285/7/1091922857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.202181,
-    "geom:area_square_m":2422157051.137527,
+    "geom:area_square_m":2422157051.13747,
     "geom:bbox":"48.4484696785,14.036250114,49.0056048676,14.6532450428",
     "geom:latitude":14.335967,
     "geom:longitude":48.724701,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.BM",
         "wd:id":"Q4117805"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893104,
-    "wof:geomhash":"515b6e6254fa05a0773a011fab85976e",
+    "wof:geomhash":"02ce053cc5f022b28b4331c9b0694006",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922857,
-    "wof:lastmodified":1566660281,
+    "wof:lastmodified":1695886507,
     "wof:name":"Brom Mayfa",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/289/1/1091922891.geojson
+++ b/data/109/192/289/1/1091922891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297525,
-    "geom:area_square_m":3552641322.070445,
+    "geom:area_square_m":3552641322.070345,
     "geom:bbox":"47.9899973371,14.6730392625,48.6246438947,15.4277426227",
     "geom:latitude":15.055824,
     "geom:longitude":48.33119,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.DA",
         "wd:id":"Q4117696"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893105,
-    "wof:geomhash":"566ceaab8b9155fbffa47f7e3f9297b8",
+    "wof:geomhash":"7a6428412c856aba0d5f081a1a46e1c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922891,
-    "wof:lastmodified":1566660251,
+    "wof:lastmodified":1695886495,
     "wof:name":"Daw'an",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/292/9/1091922929.geojson
+++ b/data/109/192/292/9/1091922929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199201,
-    "geom:area_square_m":2380468595.278793,
+    "geom:area_square_m":2380468548.221463,
     "geom:bbox":"48.580562,14.654892,49.467561,15.104835",
     "geom:latitude":14.888043,
     "geom:longitude":49.060738,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HA.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893106,
-    "wof:geomhash":"4d87e4fb6d7fb52f62bf34c16a11e5c1",
+    "wof:geomhash":"8a997fab9e8c6606a4725e6ea939b47d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091922929,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Ghayl Ba Wazir",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/296/3/1091922963.geojson
+++ b/data/109/192/296/3/1091922963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.40162,
-    "geom:area_square_m":4788444399.340961,
+    "geom:area_square_m":4788444399.341029,
     "geom:bbox":"48.744536264,14.9591176494,49.8283648913,15.8215090461",
     "geom:latitude":15.370978,
     "geom:longitude":49.279022,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.GY",
         "wd:id":"Q4117704"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893107,
-    "wof:geomhash":"00018a9d5789000fddb6b4dd170e1f31",
+    "wof:geomhash":"88fd4fc7e1312256ea89b2e8fedab555",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922963,
-    "wof:lastmodified":1566660286,
+    "wof:lastmodified":1695886509,
     "wof:name":"Ghayl Bin Yamin",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/298/3/1091922983.geojson
+++ b/data/109/192/298/3/1091922983.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252395,
-    "geom:area_square_m":2995776943.498383,
+    "geom:area_square_m":2995776943.498651,
     "geom:bbox":"47.5417640651,15.9841530364,48.3651316785,16.6276791282",
     "geom:latitude":16.27962,
     "geom:longitude":47.968082,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.HS",
         "wd:id":"Q4117648"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893108,
-    "wof:geomhash":"02124da5dd3dcd300b5497b6745b3cbb",
+    "wof:geomhash":"043ffab5b7f23c15902f167992d91911",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091922983,
-    "wof:lastmodified":1566660285,
+    "wof:lastmodified":1695886509,
     "wof:name":"Hagr As Sai'ar",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/301/5/1091923015.geojson
+++ b/data/109/192/301/5/1091923015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.273191,
-    "geom:area_square_m":3270655499.226411,
+    "geom:area_square_m":3270655499.226114,
     "geom:bbox":"47.9126471782,14.1949209516,48.6424134173,14.748909807",
     "geom:latitude":14.485825,
     "geom:longitude":48.290444,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.HA",
         "wd:id":"Q4117687"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893109,
-    "wof:geomhash":"ba590c432f25123e9052c3b27ffd65f7",
+    "wof:geomhash":"5c8e1b4aeaa5fdc9f5deeea75c30fa4d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923015,
-    "wof:lastmodified":1566660247,
+    "wof:lastmodified":1695886493,
     "wof:name":"Hajr",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/304/3/1091923043.geojson
+++ b/data/109/192/304/3/1091923043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.084394,
-    "geom:area_square_m":1005418250.365143,
+    "geom:area_square_m":1005418250.365181,
     "geom:bbox":"47.9246110822,15.3977130443,48.3812237029,15.6966235532",
     "geom:latitude":15.536708,
     "geom:longitude":48.168783,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.HU",
         "wd:id":"Q4118387"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893110,
-    "wof:geomhash":"481e65d504f49f5bc277ba37e695d226",
+    "wof:geomhash":"0924a25f67148bb70162bb1ad3379d9f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923043,
-    "wof:lastmodified":1566660273,
+    "wof:lastmodified":1695886504,
     "wof:name":"Huraidhah",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/307/7/1091923077.geojson
+++ b/data/109/192/307/7/1091923077.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062043,
-    "geom:area_square_m":739394920.311898,
+    "geom:area_square_m":739394920.311786,
     "geom:bbox":"47.5975879862,15.2102248962,47.9488855528,15.7115300268",
     "geom:latitude":15.466339,
     "geom:longitude":47.775231,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.RA",
         "wd:id":"Q4117554"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893111,
-    "wof:geomhash":"e2ae1e4dafeed01a29359399515ee38e",
+    "wof:geomhash":"0e17eb2fc82514e73225f35650776d22",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923077,
-    "wof:lastmodified":1566660243,
+    "wof:lastmodified":1695886491,
     "wof:name":"Rakhyah",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/311/3/1091923113.geojson
+++ b/data/109/192/311/3/1091923113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.245603,
-    "geom:area_square_m":26414685284.228588,
+    "geom:area_square_m":26414685284.227753,
     "geom:bbox":"50.1519054423,16.6332188088,51.9634005857,18.9937728492",
     "geom:latitude":17.948034,
     "geom:longitude":50.881005,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.RU",
         "wd:id":"Q4117633"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893112,
-    "wof:geomhash":"78d8c2ec7a1360af8be3a3bc080ffe42",
+    "wof:geomhash":"1aa152a0f8fa6a097fe3d3031936d642",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923113,
-    "wof:lastmodified":1566660290,
+    "wof:lastmodified":1695886512,
     "wof:name":"Rumah",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/312/7/1091923127.geojson
+++ b/data/109/192/312/7/1091923127.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.212986,
-    "geom:area_square_m":2537524857.726571,
+    "geom:area_square_m":2537524857.726351,
     "geom:bbox":"48.6310508738,15.2198270079,49.1610271026,15.848296776",
     "geom:latitude":15.524616,
     "geom:longitude":48.894704,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.SA",
         "wd:id":"Q4117543"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893113,
-    "wof:geomhash":"45d396d24f9c979aa1051420c13a2e20",
+    "wof:geomhash":"2bb73d3b4495d06f3eb4963df77b6e3b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923127,
-    "wof:lastmodified":1566660266,
+    "wof:lastmodified":1695886501,
     "wof:name":"Sah",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/316/3/1091923163.geojson
+++ b/data/109/192/316/3/1091923163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.067685,
-    "geom:area_square_m":804642281.282357,
+    "geom:area_square_m":804642602.354084,
     "geom:bbox":"48.689494,15.740415,48.973066,16.224303",
     "geom:latitude":15.968145,
     "geom:longitude":48.806816,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.SY",
         "wd:id":"Q4117557"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893114,
-    "wof:geomhash":"bca9df0db5c594c7d713c4098735f4b0",
+    "wof:geomhash":"96cb43f3b35764eceafe27b7828bfd5d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923163,
-    "wof:lastmodified":1690925013,
+    "wof:lastmodified":1695886512,
     "wof:name":"Sayun",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/319/7/1091923197.geojson
+++ b/data/109/192/319/7/1091923197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094176,
-    "geom:area_square_m":1120152285.31166,
+    "geom:area_square_m":1120152209.510172,
     "geom:bbox":"48.521661,15.544821,48.786139,16.199976",
     "geom:latitude":15.862817,
     "geom:longitude":48.642084,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.HA.SB",
         "wd:id":"Q4117552"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893115,
-    "wof:geomhash":"c05cf03d62aa26254b5ca465c1f2860e",
+    "wof:geomhash":"2c585be97a09482d8cece23a61a8403b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091923197,
-    "wof:lastmodified":1690925019,
+    "wof:lastmodified":1695886513,
     "wof:name":"Shibam",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/322/9/1091923229.geojson
+++ b/data/109/192/322/9/1091923229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.243598,
-    "geom:area_square_m":2894405067.553028,
+    "geom:area_square_m":2894404822.326771,
     "geom:bbox":"48.756944,15.661966,49.287832,16.471044",
     "geom:latitude":16.070614,
     "geom:longitude":49.044036,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.HA.TA",
         "wd:id":"Q4117824"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893116,
-    "wof:geomhash":"06a4bcafe161ee713aec8a233a2be21a",
+    "wof:geomhash":"05216b586500dc90bd26ee0006e0a6b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091923229,
-    "wof:lastmodified":1636497422,
+    "wof:lastmodified":1695886735,
     "wof:name":"Tarim",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/325/5/1091923255.geojson
+++ b/data/109/192/325/5/1091923255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.376073,
-    "geom:area_square_m":16219928118.09182,
+    "geom:area_square_m":16219928118.091492,
     "geom:bbox":"49.154544216,16.4741816157,50.3280222127,18.739417563",
     "geom:latitude":17.578031,
     "geom:longitude":49.931476,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.TH",
         "wd:id":"Q4117622"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893117,
-    "wof:geomhash":"bb6070c644e73db0fb3a8094c636aeb9",
+    "wof:geomhash":"1cbf34e8846de9c842246c360658a76c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923255,
-    "wof:lastmodified":1566660270,
+    "wof:lastmodified":1695886502,
     "wof:name":"Thamud",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/328/5/1091923285.geojson
+++ b/data/109/192/328/5/1091923285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.191168,
-    "geom:area_square_m":2278013897.370979,
+    "geom:area_square_m":2278013897.371078,
     "geom:bbox":"47.8731320043,15.0769528685,48.7659846278,15.8253557409",
     "geom:latitude":15.484981,
     "geom:longitude":48.418708,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.WA",
         "wd:id":"Q4117652"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893118,
-    "wof:geomhash":"46367fd11fec3fc11459221a1f4d9227",
+    "wof:geomhash":"70f19efe4d4318e11ea9ea8eecc80e03",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923285,
-    "wof:lastmodified":1566660292,
+    "wof:lastmodified":1695886512,
     "wof:name":"Wadi Al Ayn",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/331/9/1091923319.geojson
+++ b/data/109/192/331/9/1091923319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146169,
-    "geom:area_square_m":1748085155.615376,
+    "geom:area_square_m":1748085155.615188,
     "geom:bbox":"47.4384562847,14.4823252368,48.0344124385,14.9547330219",
     "geom:latitude":14.719947,
     "geom:longitude":47.749112,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HA.YA",
         "wd:id":"Q4117608"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893119,
-    "wof:geomhash":"d09f39fa02cbc7477013f5475d88191d",
+    "wof:geomhash":"33c4c11529949e145db4d7599af49513",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923319,
-    "wof:lastmodified":1566660244,
+    "wof:lastmodified":1695886491,
     "wof:name":"Yabuth",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/335/1/1091923351.geojson
+++ b/data/109/192/335/1/1091923351.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.921571,
-    "geom:area_square_m":22709052762.114315,
+    "geom:area_square_m":22709052762.114372,
     "geom:bbox":"46.8136184771,16.043260265,48.5949047153,18.3625792527",
     "geom:latitude":17.101381,
     "geom:longitude":47.861108,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HA.ZM",
         "wd:id":"Q4117646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893121,
-    "wof:geomhash":"17c26d8bfc8816a9e35db1a6fc8d108f",
+    "wof:geomhash":"54570ae196a956d0d65c1726370be32c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923351,
-    "wof:lastmodified":1566660274,
+    "wof:lastmodified":1695886504,
     "wof:name":"Zamakh wa Manwakh",
     "wof:parent_id":85681025,
     "wof:placetype":"county",

--- a/data/109/192/338/5/1091923385.geojson
+++ b/data/109/192/338/5/1091923385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.12814,
-    "geom:area_square_m":1523005657.277406,
+    "geom:area_square_m":1523005657.277391,
     "geom:bbox":"42.8063158529,15.8071828467,43.2875170419,16.2392960482",
     "geom:latitude":16.011066,
     "geom:longitude":43.059064,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.AB",
         "wd:id":"Q4117405"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893122,
-    "wof:geomhash":"7c5f504ab09c3db29b3902b441320324",
+    "wof:geomhash":"fc07d6efb631395f92af012307ce59f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091923385,
-    "wof:lastmodified":1566660244,
+    "wof:lastmodified":1695886491,
     "wof:name":"Abs",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/341/3/1091923413.geojson
+++ b/data/109/192/341/3/1091923413.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00327,
-    "geom:area_square_m":38875140.870289,
+    "geom:area_square_m":38875172.083455,
     "geom:bbox":"43.378707,15.919246,43.432962,16.017988",
     "geom:latitude":15.973258,
     "geom:longitude":43.410582,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.AY",
         "wd:id":"Q4117521"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893123,
-    "wof:geomhash":"fbe41b2bbda1de8cf13e727c9627d671",
+    "wof:geomhash":"1c3d28772388de8f63d2e01e6903715a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923413,
-    "wof:lastmodified":1690924958,
+    "wof:lastmodified":1695886500,
     "wof:name":"Aflah Al Yaman",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/344/9/1091923449.geojson
+++ b/data/109/192/344/9/1091923449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003521,
-    "geom:area_square_m":41845383.941147,
+    "geom:area_square_m":41845347.130145,
     "geom:bbox":"43.383225,16.009207,43.446897,16.096422",
     "geom:latitude":16.050421,
     "geom:longitude":43.413249,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.AS",
         "wd:id":"Q4117422"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893124,
-    "wof:geomhash":"ecef7ec632d3707a92510fca14de8e86",
+    "wof:geomhash":"360ce6af6a2fd3d25fb47b8b25c24190",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923449,
-    "wof:lastmodified":1690925021,
+    "wof:lastmodified":1695886513,
     "wof:name":"Aflah Ash Shawm",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/348/3/1091923483.geojson
+++ b/data/109/192/348/3/1091923483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013158,
-    "geom:area_square_m":156370403.018696,
+    "geom:area_square_m":156370403.018708,
     "geom:bbox":"43.4365722419,15.9586873928,43.6248610302,16.0998588848",
     "geom:latitude":16.040259,
     "geom:longitude":43.547693,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.JA",
         "wd:id":"Q4117517"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893125,
-    "wof:geomhash":"ae3a35214bf71fee3e8ca7af5361e66a",
+    "wof:geomhash":"440889cfc5813e59cc6b0903d6fa6419",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923483,
-    "wof:lastmodified":1566660264,
+    "wof:lastmodified":1695886500,
     "wof:name":"Al Jamimah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/364/7/1091923647.geojson
+++ b/data/109/192/364/7/1091923647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024004,
-    "geom:area_square_m":285469003.168605,
+    "geom:area_square_m":285469003.168639,
     "geom:bbox":"43.5033386213,15.7862458117,43.7130182702,15.9979190472",
     "geom:latitude":15.895368,
     "geom:longitude":43.626175,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.HJ.MG",
         "wd:id":"Q4117504"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893126,
-    "wof:geomhash":"94a0b94fda19f816b8edc40e431efbad",
+    "wof:geomhash":"a4aed5877dfdbbb90a2c61004612d93b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091923647,
-    "wof:lastmodified":1566660247,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Maghrabah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/367/5/1091923675.geojson
+++ b/data/109/192/367/5/1091923675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007057,
-    "geom:area_square_m":83913970.556007,
+    "geom:area_square_m":83913970.556004,
     "geom:bbox":"43.3713922085,15.8702842794,43.5311064236,15.990491048",
     "geom:latitude":15.926037,
     "geom:longitude":43.459529,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.MH",
         "wd:id":"Q4117340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893132,
-    "wof:geomhash":"8fa2388eb2ffe9438b465a93fc876877",
+    "wof:geomhash":"3929a4eb77117f9b580b3ebe4e0a44cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923675,
-    "wof:lastmodified":1566660275,
+    "wof:lastmodified":1695886505,
     "wof:name":"Al Mahabishah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/368/9/1091923689.geojson
+++ b/data/109/192/368/9/1091923689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00592,
-    "geom:area_square_m":70383111.197019,
+    "geom:area_square_m":70383111.197021,
     "geom:bbox":"43.4484221903,15.9243521217,43.5850515766,15.9968828847",
     "geom:latitude":15.958776,
     "geom:longitude":43.51676,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.MF",
         "wd:id":"Q285269"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893133,
-    "wof:geomhash":"1ccc3ae7bd7cd04b4d67c7678027b55f",
+    "wof:geomhash":"84693243265f160679baa66d150c008c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923689,
-    "wof:lastmodified":1566660272,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Miftah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/370/3/1091923703.geojson
+++ b/data/109/192/370/3/1091923703.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01162,
-    "geom:area_square_m":138389342.139004,
+    "geom:area_square_m":138389575.143553,
     "geom:bbox":"43.430581,15.542865,43.569208,15.669048",
     "geom:latitude":15.600084,
     "geom:longitude":43.495783,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.SG",
         "wd:id":"Q4117322"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893134,
-    "wof:geomhash":"313b106976dcdead9b5d896023e73967",
+    "wof:geomhash":"ad628177d6be357224275faa5be9abe7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923703,
-    "wof:lastmodified":1690924959,
+    "wof:lastmodified":1695886500,
     "wof:name":"Ash Shaghadirah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/371/9/1091923719.geojson
+++ b/data/109/192/371/9/1091923719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00898,
-    "geom:area_square_m":106809061.671366,
+    "geom:area_square_m":106808838.013768,
     "geom:bbox":"43.373238,15.81337,43.531357,15.899162",
     "geom:latitude":15.858763,
     "geom:longitude":43.447186,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.SH",
         "wd:id":"Q4804442"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893135,
-    "wof:geomhash":"b3cf218bcc75694b1b9f9c36b91d84bf",
+    "wof:geomhash":"a0613e4a36b5812274e0c445f86732cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923719,
-    "wof:lastmodified":1690924964,
+    "wof:lastmodified":1695886501,
     "wof:name":"Ash Shahil",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/374/3/1091923743.geojson
+++ b/data/109/192/374/3/1091923743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.021561,
-    "geom:area_square_m":256195056.110585,
+    "geom:area_square_m":256195027.322682,
     "geom:bbox":"43.220194,15.93416,43.365241,16.189821",
     "geom:latitude":16.065506,
     "geom:longitude":43.290127,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.HJ.AL",
         "wd:id":"Q4117502"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893136,
-    "wof:geomhash":"f0a37efe751b137ed879f7b34bda7514",
+    "wof:geomhash":"a4707a9fe9548b34da86bdff41a37fbc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091923743,
-    "wof:lastmodified":1690925015,
+    "wof:lastmodified":1695886512,
     "wof:name":"Aslem",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/376/9/1091923769.geojson
+++ b/data/109/192/376/9/1091923769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054781,
-    "geom:area_square_m":649364519.494499,
+    "geom:area_square_m":649364519.494608,
     "geom:bbox":"43.1934656769,16.3679148809,43.5326492014,16.6480231672",
     "geom:latitude":16.533757,
     "geom:longitude":43.357759,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.BM",
         "wd:id":"Q4117425"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893137,
-    "wof:geomhash":"298b6cc82b4f48f1f1f83e8c9a2a8b50",
+    "wof:geomhash":"5965626943f7a7aaa7994f2ba0e4be29",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923769,
-    "wof:lastmodified":1566660267,
+    "wof:lastmodified":1695886501,
     "wof:name":"Bakil Al Mir",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/379/5/1091923795.geojson
+++ b/data/109/192/379/5/1091923795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007305,
-    "geom:area_square_m":87010541.182722,
+    "geom:area_square_m":87010373.650293,
     "geom:bbox":"43.547572,15.531743,43.666898,15.629918",
     "geom:latitude":15.57773,
     "geom:longitude":43.605585,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.BA",
         "wd:id":"Q4117407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893139,
-    "wof:geomhash":"c2254dff50a817c648867e5cacc701d6",
+    "wof:geomhash":"bdc675dad6ac771decaec2f5551123c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923795,
-    "wof:lastmodified":1690924957,
+    "wof:lastmodified":1695886500,
     "wof:name":"Bani Al Awam",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/382/7/1091923827.geojson
+++ b/data/109/192/382/7/1091923827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043759,
-    "geom:area_square_m":521083695.370804,
+    "geom:area_square_m":521083502.185349,
     "geom:bbox":"43.220983,15.510535,43.451506,15.761435",
     "geom:latitude":15.629679,
     "geom:longitude":43.33575,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.BQ",
         "wd:id":"Q4117530"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893140,
-    "wof:geomhash":"d3d41faaf431ab7a1f88b0cad346bfee",
+    "wof:geomhash":"cead50e0a1cedfaac46f26d64b3bdd00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923827,
-    "wof:lastmodified":1690924965,
+    "wof:lastmodified":1695886502,
     "wof:name":"Bani Qa'is",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/385/9/1091923859.geojson
+++ b/data/109/192/385/9/1091923859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006525,
-    "geom:area_square_m":77693045.757712,
+    "geom:area_square_m":77692888.321922,
     "geom:bbox":"43.421456,15.611326,43.657503,15.713018",
     "geom:latitude":15.661144,
     "geom:longitude":43.549658,
@@ -119,9 +119,10 @@
         "hasc:id":"YE.HJ.HJ",
         "wd:id":"Q4117505"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893141,
-    "wof:geomhash":"0a3e0403d04e4138177862511ebf3b7f",
+    "wof:geomhash":"b0b081ea06c36c1e0231289541f9bd7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1091923859,
-    "wof:lastmodified":1690924963,
+    "wof:lastmodified":1695886735,
     "wof:name":"Hajjah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/388/5/1091923885.geojson
+++ b/data/109/192/388/5/1091923885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00357,
-    "geom:area_square_m":42495330.669553,
+    "geom:area_square_m":42495278.037969,
     "geom:bbox":"43.551835,15.655691,43.632307,15.720753",
     "geom:latitude":15.68836,
     "geom:longitude":43.597005,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HJ.HC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893142,
-    "wof:geomhash":"90d634fa126741d6688137752420f22b",
+    "wof:geomhash":"ec3b268b10c43c6ea5665b70b7906fc7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091923885,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Hajjah City",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/389/9/1091923899.geojson
+++ b/data/109/192/389/9/1091923899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081007,
-    "geom:area_square_m":960759888.941426,
+    "geom:area_square_m":960759888.941502,
     "geom:bbox":"42.937972,16.2651195805,43.2767125858,16.67725",
     "geom:latitude":16.431986,
     "geom:longitude":43.116547,
@@ -93,9 +93,10 @@
         "hasc:id":"YE.HJ.HD",
         "wd:id":"Q1884189"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893143,
-    "wof:geomhash":"35bfa1ad571fa65e76d527064ae9056e",
+    "wof:geomhash":"9566d24c907b264ca542b6740e9afc4c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091923899,
-    "wof:lastmodified":1566660291,
+    "wof:lastmodified":1695886512,
     "wof:name":"Harad",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/392/5/1091923925.geojson
+++ b/data/109/192/392/5/1091923925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014869,
-    "geom:area_square_m":176513611.934698,
+    "geom:area_square_m":176513662.758326,
     "geom:bbox":"42.949503,16.19945,43.172307,16.301668",
     "geom:latitude":16.253456,
     "geom:longitude":43.053828,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.HR",
         "wd:id":"Q4117436"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893144,
-    "wof:geomhash":"75add467a56646e33ceb435bded83794",
+    "wof:geomhash":"c7f4d2b9db3442aebeef9d4646c2936d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923925,
-    "wof:lastmodified":1690924970,
+    "wof:lastmodified":1695886503,
     "wof:name":"Hayran",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/395/3/1091923953.geojson
+++ b/data/109/192/395/3/1091923953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012911,
-    "geom:area_square_m":153379927.037896,
+    "geom:area_square_m":153379933.263349,
     "geom:bbox":"43.283938,15.943736,43.400114,16.204019",
     "geom:latitude":16.102418,
     "geom:longitude":43.353528,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.KM",
         "wd:id":"Q4117331"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893145,
-    "wof:geomhash":"a84a90881152d6ecf3f547db0cae73b4",
+    "wof:geomhash":"c3e992ab47452e3655188b1b5c56303f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923953,
-    "wof:lastmodified":1690924970,
+    "wof:lastmodified":1695886503,
     "wof:name":"Khayran Al Muharraq",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/398/1/1091923981.geojson
+++ b/data/109/192/398/1/1091923981.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03772,
-    "geom:area_square_m":448766116.636622,
+    "geom:area_square_m":448766161.299381,
     "geom:bbox":"43.210708,15.679229,43.509733,15.958417",
     "geom:latitude":15.81354,
     "geom:longitude":43.328794,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.KD",
         "wd:id":"Q4117507"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893146,
-    "wof:geomhash":"b77bbe519b5d7396bce290667aa51db6",
+    "wof:geomhash":"a4b26413198b98a1542429d5e03b3f60",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091923981,
-    "wof:lastmodified":1690924919,
+    "wof:lastmodified":1695886492,
     "wof:name":"Ku'aydinah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/401/3/1091924013.geojson
+++ b/data/109/192/401/3/1091924013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011369,
-    "geom:area_square_m":135293474.585506,
+    "geom:area_square_m":135293236.832984,
     "geom:bbox":"43.639681,15.654284,43.757324,15.857595",
     "geom:latitude":15.763455,
     "geom:longitude":43.695995,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.HJ.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893147,
-    "wof:geomhash":"b131506bb2bc12f2669934d2a74a832b",
+    "wof:geomhash":"2cc31d9a465d5ac08b174c7b3973eda3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091924013,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Kuhlan Affar",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/403/3/1091924033.geojson
+++ b/data/109/192/403/3/1091924033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005661,
-    "geom:area_square_m":67284983.012332,
+    "geom:area_square_m":67285172.301348,
     "geom:bbox":"43.426251,15.98,43.547917,16.068351",
     "geom:latitude":16.020174,
     "geom:longitude":43.473456,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.KS",
         "wd:id":"Q4117527"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893149,
-    "wof:geomhash":"035286d1256eff53d723e97da7e409c1",
+    "wof:geomhash":"25bf30c72f0a0e8ed2c8467ec4a33465",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924033,
-    "wof:lastmodified":1690925008,
+    "wof:lastmodified":1695886511,
     "wof:name":"Kuhlan Ash Sharaf",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/405/9/1091924059.geojson
+++ b/data/109/192/405/9/1091924059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028883,
-    "geom:area_square_m":343012071.885201,
+    "geom:area_square_m":343012094.65017,
     "geom:bbox":"43.369569,16.080287,43.57571,16.262935",
     "geom:latitude":16.170512,
     "geom:longitude":43.472263,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.KU",
         "wd:id":"Q4117508"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893150,
-    "wof:geomhash":"428a73912014ab3e77a2169b89fdf988",
+    "wof:geomhash":"fb5e7ba85bdb8a00d9dc46889a095c59",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924059,
-    "wof:lastmodified":1690925001,
+    "wof:lastmodified":1695886509,
     "wof:name":"Kushar",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/408/9/1091924089.geojson
+++ b/data/109/192/408/9/1091924089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016712,
-    "geom:area_square_m":198873153.649696,
+    "geom:area_square_m":198873202.291652,
     "geom:bbox":"43.480941,15.671862,43.619762,15.867185",
     "geom:latitude":15.763028,
     "geom:longitude":43.547693,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.MB",
         "wd:id":"Q4117532"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893151,
-    "wof:geomhash":"19b38acfdad87d0e313b981a875e4d25",
+    "wof:geomhash":"4cfaca9d405b2ba3ffb451488e3760e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924089,
-    "wof:lastmodified":1690924942,
+    "wof:lastmodified":1695886497,
     "wof:name":"Mabyan",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/412/5/1091924125.geojson
+++ b/data/109/192/412/5/1091924125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062876,
-    "geom:area_square_m":746558283.184766,
+    "geom:area_square_m":746558353.621996,
     "geom:bbox":"42.190388,15.949882,42.993885,16.40744",
     "geom:latitude":16.211983,
     "geom:longitude":42.849694,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.MD",
         "wd:id":"Q4117541"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893152,
-    "wof:geomhash":"285e8853857b049146f615908a992772",
+    "wof:geomhash":"acbfe75994faba16c79e3a8b0619f704",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924125,
-    "wof:lastmodified":1690924937,
+    "wof:lastmodified":1695886495,
     "wof:name":"Midi",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/415/1/1091924151.geojson
+++ b/data/109/192/415/1/1091924151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024039,
-    "geom:area_square_m":285352647.04117,
+    "geom:area_square_m":285352767.957365,
     "geom:bbox":"43.158159,16.174405,43.376495,16.37248",
     "geom:latitude":16.26264,
     "geom:longitude":43.277125,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.MU",
         "wd:id":"Q4117513"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893153,
-    "wof:geomhash":"8ba0fbb5bc00657ed02efee75a15d4c6",
+    "wof:geomhash":"cf9eb8017495cb4d48087e34a6770462",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924151,
-    "wof:lastmodified":1690924936,
+    "wof:lastmodified":1695886496,
     "wof:name":"Mustaba",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/417/7/1091924177.geojson
+++ b/data/109/192/417/7/1091924177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00311,
-    "geom:area_square_m":37031233.48313,
+    "geom:area_square_m":37031415.407746,
     "geom:bbox":"43.50926,15.609469,43.5773,15.686536",
     "geom:latitude":15.647375,
     "geom:longitude":43.543536,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.NA",
         "wd:id":"Q4117428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893154,
-    "wof:geomhash":"06866e1973dc2ede7ce39f3eff1f9a74",
+    "wof:geomhash":"b7686a58fc6b64d57790c78bb5c08ab6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924177,
-    "wof:lastmodified":1690924983,
+    "wof:lastmodified":1695886505,
     "wof:name":"Najrah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/420/9/1091924209.geojson
+++ b/data/109/192/420/9/1091924209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007185,
-    "geom:area_square_m":85441956.797315,
+    "geom:area_square_m":85442022.099006,
     "geom:bbox":"43.299158,15.858782,43.424987,15.954976",
     "geom:latitude":15.910072,
     "geom:longitude":43.356634,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.QS",
         "wd:id":"Q4117511"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893155,
-    "wof:geomhash":"00517258ec57ccc87572fd12422de298",
+    "wof:geomhash":"23e0af7719adb509a2f330e8814fea13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924209,
-    "wof:lastmodified":1690924989,
+    "wof:lastmodified":1695886506,
     "wof:name":"Qafl Shamer",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/423/9/1091924239.geojson
+++ b/data/109/192/423/9/1091924239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025303,
-    "geom:area_square_m":300143951.705319,
+    "geom:area_square_m":300144035.601379,
     "geom:bbox":"43.40611,16.25941,43.540318,16.542761",
     "geom:latitude":16.398941,
     "geom:longitude":43.47883,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.QA",
         "wd:id":"Q4117506"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893156,
-    "wof:geomhash":"db9baad5787861a2683e52115bb1f57f",
+    "wof:geomhash":"73a150c58a8cfb59ef6f082c75adbc7b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924239,
-    "wof:lastmodified":1690924939,
+    "wof:lastmodified":1695886496,
     "wof:name":"Qarah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/426/7/1091924267.geojson
+++ b/data/109/192/426/7/1091924267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006302,
-    "geom:area_square_m":75010932.557263,
+    "geom:area_square_m":75010982.332128,
     "geom:bbox":"43.608621,15.658295,43.700524,15.799915",
     "geom:latitude":15.723425,
     "geom:longitude":43.652424,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.HJ.SR",
         "wd:id":"Q4117343"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893157,
-    "wof:geomhash":"6d2984daacca1f016844e421bcd20f2f",
+    "wof:geomhash":"99778cb94042fbf7d927b61d49a8d952",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924267,
-    "wof:lastmodified":1690924982,
+    "wof:lastmodified":1695886505,
     "wof:name":"Sharas",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/429/7/1091924297.geojson
+++ b/data/109/192/429/7/1091924297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001962,
-    "geom:area_square_m":23349392.733626,
+    "geom:area_square_m":23349333.141401,
     "geom:bbox":"43.438906,15.691361,43.49284,15.739767",
     "geom:latitude":15.717678,
     "geom:longitude":43.468475,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.HJ.WD",
         "wd:id":"Q4117352"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893159,
-    "wof:geomhash":"aca4eb4c48b7734c9b829780b132bbed",
+    "wof:geomhash":"73649685d1daeb0df24021771c272d21",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924297,
-    "wof:lastmodified":1690924987,
+    "wof:lastmodified":1695886506,
     "wof:name":"Wadhrah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/432/7/1091924327.geojson
+++ b/data/109/192/432/7/1091924327.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017023,
-    "geom:area_square_m":201988859.201855,
+    "geom:area_square_m":201988949.715255,
     "geom:bbox":"43.318092,16.222752,43.436579,16.452247",
     "geom:latitude":16.338468,
     "geom:longitude":43.384433,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.HJ.WH",
         "wd:id":"Q4117433"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893160,
-    "wof:geomhash":"0aa7fbf86e07de60508262bf985d3678",
+    "wof:geomhash":"9ddd4c1cf5e01334a2a25714ea2ab1a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091924327,
-    "wof:lastmodified":1690925007,
+    "wof:lastmodified":1695886510,
     "wof:name":"Washhah",
     "wof:parent_id":85680973,
     "wof:placetype":"county",

--- a/data/109/192/435/3/1091924353.geojson
+++ b/data/109/192/435/3/1091924353.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002822,
-    "geom:area_square_m":33864370.589036,
+    "geom:area_square_m":33864317.293322,
     "geom:bbox":"44.124545,13.95021,44.186202,14.010401",
     "geom:latitude":13.982035,
     "geom:longitude":44.15417,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.DH",
         "wd:id":"Q4118413"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893161,
-    "wof:geomhash":"0ba4ea1e6075aa6c156c1931342269a3",
+    "wof:geomhash":"5e5022b65fa55faa3e7c591a48b58379",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924353,
-    "wof:lastmodified":1690925007,
+    "wof:lastmodified":1695886510,
     "wof:name":"Al Dhihar",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/437/7/1091924377.geojson
+++ b/data/109/192/437/7/1091924377.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018093,
-    "geom:area_square_m":216947846.611511,
+    "geom:area_square_m":216947802.228988,
     "geom:bbox":"44.136065,14.036128,44.270352,14.238481",
     "geom:latitude":14.139244,
     "geom:longitude":44.204626,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.MK",
         "wd:id":"Q4117820"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893162,
-    "wof:geomhash":"77093ec3310b0036e7be1885c7dabc35",
+    "wof:geomhash":"03136693ef0a579641aa47b8b6a00814",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924377,
-    "wof:lastmodified":1690924942,
+    "wof:lastmodified":1695886497,
     "wof:name":"Al Makhadir",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/438/5/1091924385.geojson
+++ b/data/109/192/438/5/1091924385.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001588,
-    "geom:area_square_m":19051666.116392,
+    "geom:area_square_m":19051751.498032,
     "geom:bbox":"44.138253,13.929176,44.197749,13.98634",
     "geom:latitude":13.951881,
     "geom:longitude":44.174814,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.MN",
         "wd:id":"Q4117706"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893164,
-    "wof:geomhash":"59344cb22865f4a0b3284ded748533ab",
+    "wof:geomhash":"a90b5de9863e3151cd74dc4e9e89ef2f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924385,
-    "wof:lastmodified":1690924951,
+    "wof:lastmodified":1695886499,
     "wof:name":"Al Mashannah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/440/5/1091924405.geojson
+++ b/data/109/192/440/5/1091924405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056364,
-    "geom:area_square_m":675376146.79616,
+    "geom:area_square_m":675376269.495015,
     "geom:bbox":"43.784647,14.160441,44.273582,14.464129",
     "geom:latitude":14.292341,
     "geom:longitude":44.064143,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.QA",
         "wd:id":"Q4117691"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893165,
-    "wof:geomhash":"48bb4628c69f015d969b707b1c97d69f",
+    "wof:geomhash":"d6deb4a29fef1d2e0cf5461a324f50d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924405,
-    "wof:lastmodified":1690924926,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Qafr",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/443/5/1091924435.geojson
+++ b/data/109/192/443/5/1091924435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031026,
-    "geom:area_square_m":372282055.416656,
+    "geom:area_square_m":372281920.127406,
     "geom:bbox":"43.789885,13.85239,44.090408,14.135244",
     "geom:latitude":13.976406,
     "geom:longitude":43.9326,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.UD",
         "wd:id":"Q4117786"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893166,
-    "wof:geomhash":"493fdbd0a8fbf9ba23432d104bea9617",
+    "wof:geomhash":"1a8232218096928dde1260f9653e3194",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924435,
-    "wof:lastmodified":1690924985,
+    "wof:lastmodified":1695886506,
     "wof:name":"Al Udayn",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/446/7/1091924467.geojson
+++ b/data/109/192/446/7/1091924467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023844,
-    "geom:area_square_m":286000907.060237,
+    "geom:area_square_m":286000656.973834,
     "geom:bbox":"44.39267,13.960096,44.605269,14.168249",
     "geom:latitude":14.063933,
     "geom:longitude":44.502752,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.NA",
         "wd:id":"Q4118324"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893167,
-    "wof:geomhash":"51daa08b0e047e00121ed2b889734bb7",
+    "wof:geomhash":"c4153bc0543760ec337e2bfe0532ddcf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924467,
-    "wof:lastmodified":1690924934,
+    "wof:lastmodified":1695886495,
     "wof:name":"An Nadirah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/448/3/1091924483.geojson
+++ b/data/109/192/448/3/1091924483.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.024533,
-    "geom:area_square_m":294067754.838671,
+    "geom:area_square_m":294067901.716436,
     "geom:bbox":"44.446279,14.123851,44.681302,14.300882",
     "geom:latitude":14.213055,
     "geom:longitude":44.561118,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.RA",
         "wd:id":"Q4117625"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893168,
-    "wof:geomhash":"7a6a0e7dae10b269ad0e55e86a6c4f57",
+    "wof:geomhash":"3ce79eb5fe8965d10947fbce1198f4b6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924483,
-    "wof:lastmodified":1690924932,
+    "wof:lastmodified":1695886495,
     "wof:name":"Ar Radmah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/450/3/1091924503.geojson
+++ b/data/109/192/450/3/1091924503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.028334,
-    "geom:area_square_m":340190090.323313,
+    "geom:area_square_m":340190501.275751,
     "geom:bbox":"44.242892,13.703592,44.435698,13.977055",
     "geom:latitude":13.834882,
     "geom:longitude":44.327923,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.SB",
         "wd:id":"Q4117612"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893170,
-    "wof:geomhash":"1a20c1d1de5e4b060b9deebc04e82420",
+    "wof:geomhash":"9d09be56cecb31e8af8297a40bd9178c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924503,
-    "wof:lastmodified":1690925005,
+    "wof:lastmodified":1695886510,
     "wof:name":"As Sabrah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/450/7/1091924507.geojson
+++ b/data/109/192/450/7/1091924507.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022249,
-    "geom:area_square_m":266759013.614769,
+    "geom:area_square_m":266759089.894118,
     "geom:bbox":"44.252083,14.076875,44.498659,14.254097",
     "geom:latitude":14.157081,
     "geom:longitude":44.393167,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.SD",
         "wd:id":"Q4117599"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893171,
-    "wof:geomhash":"f0526c0c9eec3b0b86965e40401275fc",
+    "wof:geomhash":"69b2e5302c099ca343c15d6131834114",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924507,
-    "wof:lastmodified":1690925004,
+    "wof:lastmodified":1695886510,
     "wof:name":"As Saddah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/450/9/1091924509.geojson
+++ b/data/109/192/450/9/1091924509.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019799,
-    "geom:area_square_m":237725440.679423,
+    "geom:area_square_m":237725092.06315,
     "geom:bbox":"44.129756,13.71905,44.28818,13.930378",
     "geom:latitude":13.826603,
     "geom:longitude":44.204636,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.SY",
         "wd:id":"Q4117787"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893172,
-    "wof:geomhash":"0d6882e4bb95893f4c3ec90ddef4bc3e",
+    "wof:geomhash":"74948cedf787b6b39b7c8dbf0f8b23d3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924509,
-    "wof:lastmodified":1690925004,
+    "wof:lastmodified":1695886510,
     "wof:name":"As Sayyani",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/451/1/1091924511.geojson
+++ b/data/109/192/451/1/1091924511.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011459,
-    "geom:area_square_m":137467494.90767,
+    "geom:area_square_m":137467602.761734,
     "geom:bbox":"44.279644,13.96825,44.453028,14.09392",
     "geom:latitude":14.036487,
     "geom:longitude":44.36999,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.SH",
         "wd:id":"Q4118427"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893173,
-    "wof:geomhash":"81377340f7019b99fa8cda97d23f89e6",
+    "wof:geomhash":"46cf0f45de92dc1c03021cd8b83ad8d4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924511,
-    "wof:lastmodified":1690925000,
+    "wof:lastmodified":1695886508,
     "wof:name":"Ash Sha'ir",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/451/3/1091924513.geojson
+++ b/data/109/192/451/3/1091924513.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020033,
-    "geom:area_square_m":240374123.293536,
+    "geom:area_square_m":240373820.835536,
     "geom:bbox":"44.199145,13.886851,44.459035,14.092022",
     "geom:latitude":13.982008,
     "geom:longitude":44.325254,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.BA",
         "wd:id":"Q4117700"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893174,
-    "wof:geomhash":"cb79c5d592e158cee4af4150125d0631",
+    "wof:geomhash":"75da080313f15761f41bb48575edff00",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924513,
-    "wof:lastmodified":1690925000,
+    "wof:lastmodified":1695886509,
     "wof:name":"Ba'dan",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/452/9/1091924529.geojson
+++ b/data/109/192/452/9/1091924529.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015731,
-    "geom:area_square_m":188886781.246573,
+    "geom:area_square_m":188886654.726289,
     "geom:bbox":"43.986166,13.748473,44.167333,13.914623",
     "geom:latitude":13.820188,
     "geom:longitude":44.071215,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.DS",
         "wd:id":"Q4118321"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893175,
-    "wof:geomhash":"20105d27240e36ae171c33df9b671150",
+    "wof:geomhash":"7f459b9247e636c7a5d5aba8b84f5340",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924529,
-    "wof:lastmodified":1690924945,
+    "wof:lastmodified":1695886497,
     "wof:name":"Dhi As Sufal",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/455/7/1091924557.geojson
+++ b/data/109/192/455/7/1091924557.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030449,
-    "geom:area_square_m":365407487.527999,
+    "geom:area_square_m":365407796.968817,
     "geom:bbox":"43.650512,13.847394,43.913127,14.068767",
     "geom:latitude":13.944621,
     "geom:longitude":43.765518,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.FU",
         "wd:id":"Q4117678"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893176,
-    "wof:geomhash":"0e8b4bfde00c996848a666e62c3200d3",
+    "wof:geomhash":"003d5d13bcf588a03dfab2aa3dc9def2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924557,
-    "wof:lastmodified":1690924947,
+    "wof:lastmodified":1695886498,
     "wof:name":"Far Al Udayn",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/458/1/1091924581.geojson
+++ b/data/109/192/458/1/1091924581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040353,
-    "geom:area_square_m":483898687.260829,
+    "geom:area_square_m":483898503.953347,
     "geom:bbox":"43.749172,13.993184,44.060673,14.235737",
     "geom:latitude":14.119302,
     "geom:longitude":43.921764,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.HU",
         "wd:id":"Q4118421"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893177,
-    "wof:geomhash":"e73120dc37c686a4d5c5871cdd678de9",
+    "wof:geomhash":"90f8ecf0b3c7966062051126afb639cb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924581,
-    "wof:lastmodified":1690924996,
+    "wof:lastmodified":1695886508,
     "wof:name":"Hazm Al Udayn",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/459/7/1091924597.geojson
+++ b/data/109/192/459/7/1091924597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019516,
-    "geom:area_square_m":234029999.885171,
+    "geom:area_square_m":234029947.870384,
     "geom:bbox":"44.005648,14.0039,44.163819,14.228079",
     "geom:latitude":14.117647,
     "geom:longitude":44.082536,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.IB.HB",
         "wd:id":"Q4118310"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893178,
-    "wof:geomhash":"b1c751058fb5140ffe798be4cdb6759b",
+    "wof:geomhash":"0700cf85be01d2a7b34d2a6aa20f16bc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091924597,
-    "wof:lastmodified":1690925006,
+    "wof:lastmodified":1695886510,
     "wof:name":"Hubaysh",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/462/1/1091924621.geojson
+++ b/data/109/192/462/1/1091924621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015519,
-    "geom:area_square_m":186206705.922099,
+    "geom:area_square_m":186206962.927893,
     "geom:bbox":"44.048266,13.87862,44.303467,14.108168",
     "geom:latitude":13.991055,
     "geom:longitude":44.167421,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.IB.IB",
         "wd:id":"Q4117701"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893180,
-    "wof:geomhash":"14dcbc503d3d4f1197f74476c74c7f2d",
+    "wof:geomhash":"7dab5fb2a3dcc579c4be9179db2d5cdf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091924621,
-    "wof:lastmodified":1690924955,
+    "wof:lastmodified":1695886735,
     "wof:name":"Ibb",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/465/1/1091924651.geojson
+++ b/data/109/192/465/1/1091924651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01017,
-    "geom:area_square_m":122067718.007894,
+    "geom:area_square_m":122067708.128399,
     "geom:bbox":"44.025781,13.856446,44.214274,13.973582",
     "geom:latitude":13.910862,
     "geom:longitude":44.115301,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.JI",
         "wd:id":"Q4117703"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893181,
-    "wof:geomhash":"caa25e9a57e2176cd2232c4da3c5d6d5",
+    "wof:geomhash":"e0b5af0c0fe7d94d9b2e4cf8b5c72f36",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924651,
-    "wof:lastmodified":1690924954,
+    "wof:lastmodified":1695886499,
     "wof:name":"Jiblah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/467/5/1091924675.geojson
+++ b/data/109/192/467/5/1091924675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009552,
-    "geom:area_square_m":114675194.663322,
+    "geom:area_square_m":114675469.923372,
     "geom:bbox":"43.852512,13.790054,44.012579,13.913528",
     "geom:latitude":13.850305,
     "geom:longitude":43.958787,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.MU",
         "wd:id":"Q4117793"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893182,
-    "wof:geomhash":"afc4df4aac0b1d2b1973179cad2dd85f",
+    "wof:geomhash":"6b3d64af2fd7e290c91aaa930b0533a8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924675,
-    "wof:lastmodified":1690924997,
+    "wof:lastmodified":1695886508,
     "wof:name":"Mudhaykhirah",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/469/3/1091924693.geojson
+++ b/data/109/192/469/3/1091924693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045883,
-    "geom:area_square_m":549789508.562013,
+    "geom:area_square_m":549789545.610052,
     "geom:bbox":"44.153227,14.129821,44.476744,14.460098",
     "geom:latitude":14.294451,
     "geom:longitude":44.310993,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.IB.YA",
         "wd:id":"Q4117699"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893183,
-    "wof:geomhash":"2ea0e7ad7bb43b3c11df70eb184c4732",
+    "wof:geomhash":"e34d72da0f8de75900e04bea90e7806c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924693,
-    "wof:lastmodified":1690924999,
+    "wof:lastmodified":1695886509,
     "wof:name":"Yarim",
     "wof:parent_id":85680979,
     "wof:placetype":"county",

--- a/data/109/192/470/9/1091924709.geojson
+++ b/data/109/192/470/9/1091924709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02196,
-    "geom:area_square_m":263513189.86577,
+    "geom:area_square_m":263513189.865792,
     "geom:bbox":"45.1265844136,13.9006570484,45.3864947909,14.057129612",
     "geom:latitude":13.964376,
     "geom:longitude":45.278903,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.HD",
         "wd:id":"Q4117515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893184,
-    "wof:geomhash":"16f17290a0660c67ca3825e2c1973e70",
+    "wof:geomhash":"a2566aee3e3c79092c9805fb383785d7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924709,
-    "wof:lastmodified":1566660251,
+    "wof:lastmodified":1695886495,
     "wof:name":"Al Had",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/473/7/1091924737.geojson
+++ b/data/109/192/473/7/1091924737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000609,
-    "geom:area_square_m":7334573.425489,
+    "geom:area_square_m":7334573.425488,
     "geom:bbox":"44.8668913864,13.0489626894,44.8941922475,13.0776794055",
     "geom:latitude":13.063581,
     "geom:longitude":44.880921,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.LA.HT",
         "wd:id":"Q4117591"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893185,
-    "wof:geomhash":"737d39b6bbb2f6b89149afaf8af095b6",
+    "wof:geomhash":"e6b2321b1dea6c072e04fd12f6babeb7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091924737,
-    "wof:lastmodified":1566660281,
+    "wof:lastmodified":1695886507,
     "wof:name":"Al Hawtah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/476/5/1091924765.geojson
+++ b/data/109/192/476/5/1091924765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.300479,
-    "geom:area_square_m":3622543860.136959,
+    "geom:area_square_m":3622543860.13737,
     "geom:bbox":"43.5262651602,12.593610764,44.4590788068,13.121504731",
     "geom:latitude":12.841654,
     "geom:longitude":43.995771,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.MA",
         "wd:id":"Q4117571"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893186,
-    "wof:geomhash":"7df7bb5697fe976d4aa1c37fed477d96",
+    "wof:geomhash":"c7b81a50494dccba3aea45ebd1f87f3f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924765,
-    "wof:lastmodified":1566660249,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Madaribah Wa Al Arah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/478/7/1091924787.geojson
+++ b/data/109/192/478/7/1091924787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011542,
-    "geom:area_square_m":138614142.982844,
+    "geom:area_square_m":138614142.982841,
     "geom:bbox":"45.0215309861,13.7180831267,45.2023299962,13.838504496",
     "geom:latitude":13.780373,
     "geom:longitude":45.123913,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.MF",
         "wd:id":"Q4117631"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893187,
-    "wof:geomhash":"8f1ed9de5da9c6d9b3d33ee30b3e2e15",
+    "wof:geomhash":"88459215e04f10eeb33b9abdda5fe634",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924787,
-    "wof:lastmodified":1566660248,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Maflahy",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/480/1/1091924801.geojson
+++ b/data/109/192/480/1/1091924801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032556,
-    "geom:area_square_m":392049572.46524,
+    "geom:area_square_m":392049779.462166,
     "geom:bbox":"43.98878,13.024981,44.291971,13.24108",
     "geom:latitude":13.121398,
     "geom:longitude":44.163725,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.LA.MQ",
         "wd:id":"Q4117600"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893189,
-    "wof:geomhash":"6c1933bff716676fa8a455a108a6aec6",
+    "wof:geomhash":"a455df87c0779898031efcf841e507e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924801,
-    "wof:lastmodified":1690924994,
+    "wof:lastmodified":1695886508,
     "wof:name":"Al Maqatirah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/482/1/1091924821.geojson
+++ b/data/109/192/482/1/1091924821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116389,
-    "geom:area_square_m":1400419486.387897,
+    "geom:area_square_m":1400419486.387847,
     "geom:bbox":"44.6587576977,13.0714951507,45.1951255837,13.5724451261",
     "geom:latitude":13.325537,
     "geom:longitude":44.956663,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.MI",
         "wd:id":"Q4117611"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893190,
-    "wof:geomhash":"bbb0e210026dbaa7706c3aeb0ce0a4fa",
+    "wof:geomhash":"606e74493516074757e90228610a9494",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924821,
-    "wof:lastmodified":1566660249,
+    "wof:lastmodified":1695886494,
     "wof:name":"Al Milah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/484/3/1091924843.geojson
+++ b/data/109/192/484/3/1091924843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.04408,
-    "geom:area_square_m":530105529.94333,
+    "geom:area_square_m":530105529.943402,
     "geom:bbox":"44.4204295204,13.2693231185,44.7626223046,13.5886095815",
     "geom:latitude":13.452567,
     "geom:longitude":44.615715,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.MU",
         "wd:id":"Q4704515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893191,
-    "wof:geomhash":"4b7c6e84893a8b8aa0aa23d45a2acbe4",
+    "wof:geomhash":"0a43a8e7875ed0b59a686b5eae0348b4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924843,
-    "wof:lastmodified":1566660251,
+    "wof:lastmodified":1695886495,
     "wof:name":"Al Musaymir",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/485/9/1091924859.geojson
+++ b/data/109/192/485/9/1091924859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.08669,
-    "geom:area_square_m":1043125560.692471,
+    "geom:area_square_m":1043124917.065994,
     "geom:bbox":"44.307168,13.158124,44.711928,13.498841",
     "geom:latitude":13.313801,
     "geom:longitude":44.507088,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.LA.QA",
         "wd:id":"Q4117561"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893192,
-    "wof:geomhash":"1de2c0394491a7eec5fdde5ec0677815",
+    "wof:geomhash":"cbf91b1906fb3f3a9103731ddcc91523",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924859,
-    "wof:lastmodified":1690924928,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Qabbaytah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/487/5/1091924875.geojson
+++ b/data/109/192/487/5/1091924875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054188,
-    "geom:area_square_m":651285444.684173,
+    "geom:area_square_m":651285444.68418,
     "geom:bbox":"44.8601280071,13.4697565368,45.2793399508,13.7119096844",
     "geom:latitude":13.589611,
     "geom:longitude":45.075652,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.HJ",
         "wd:id":"Q4117473"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893193,
-    "wof:geomhash":"c01dd36d8269135f35f7d3971adcc8b5",
+    "wof:geomhash":"ee3a1c1b3149b46694df10ad18235768",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924875,
-    "wof:lastmodified":1566660281,
+    "wof:lastmodified":1695886507,
     "wof:name":"Habil Jabr",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/489/7/1091924897.geojson
+++ b/data/109/192/489/7/1091924897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023788,
-    "geom:area_square_m":285762099.137593,
+    "geom:area_square_m":285762319.838569,
     "geom:bbox":"44.807789,13.583397,45.079878,13.83322",
     "geom:latitude":13.709682,
     "geom:longitude":44.929889,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.LA.HL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893194,
-    "wof:geomhash":"77cbe3558c47c0f3b43ca542a901e4f9",
+    "wof:geomhash":"50181eab677ac02927632e36100844bd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091924897,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Halimayn",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/491/7/1091924917.geojson
+++ b/data/109/192/491/7/1091924917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051525,
-    "geom:area_square_m":619575873.390976,
+    "geom:area_square_m":619575873.391015,
     "geom:bbox":"44.7026496287,13.3267885907,45.2788342348,13.6079566263",
     "geom:latitude":13.475975,
     "geom:longitude":45.005243,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.RA",
         "wd:id":"Q4117512"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893195,
-    "wof:geomhash":"9ed360c936b30080d8c21df544ad3973",
+    "wof:geomhash":"d42b6f17677a0b28775a137a3a395b7f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924917,
-    "wof:lastmodified":1566660262,
+    "wof:lastmodified":1695886499,
     "wof:name":"Radfan",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/494/1/1091924941.geojson
+++ b/data/109/192/494/1/1091924941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.119744,
-    "geom:area_square_m":1442322284.134043,
+    "geom:area_square_m":1442322360.708524,
     "geom:bbox":"44.670909,12.863864,45.089633,13.321482",
     "geom:latitude":13.065878,
     "geom:longitude":44.855412,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.LA.TU",
         "wd:id":"Q4117488"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893196,
-    "wof:geomhash":"b0029a9a517d92b4704e3f7ca6b0c5e1",
+    "wof:geomhash":"3a74fd70533c0b5e19a7a9c21e509a91",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924941,
-    "wof:lastmodified":1636497423,
+    "wof:lastmodified":1695886735,
     "wof:name":"Tuban",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/496/9/1091924969.geojson
+++ b/data/109/192/496/9/1091924969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.14817,
-    "geom:area_square_m":1785025299.825935,
+    "geom:area_square_m":1785025299.826128,
     "geom:bbox":"44.2176575971,12.7814460559,44.7100726265,13.2328758582",
     "geom:latitude":13.022987,
     "geom:longitude":44.47503,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.LA.TB",
         "wd:id":"Q4117589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893197,
-    "wof:geomhash":"ada557f4474593076f9b0cb60fa323db",
+    "wof:geomhash":"0bb2b26920f103a351f87278474f6ffb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091924969,
-    "wof:lastmodified":1566660262,
+    "wof:lastmodified":1695886499,
     "wof:name":"Tur Al Bahah",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/497/9/1091924979.geojson
+++ b/data/109/192/497/9/1091924979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02336,
-    "geom:area_square_m":280438845.168269,
+    "geom:area_square_m":280438981.490103,
     "geom:bbox":"45.05679,13.792283,45.342397,13.931208",
     "geom:latitude":13.861148,
     "geom:longitude":45.217986,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.LA.YF",
         "wd:id":"Q4117606"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893198,
-    "wof:geomhash":"a862b19df1ca5ceb1fcd15ff8b04060a",
+    "wof:geomhash":"d9aa790b7ad1f6e19071cfbed1bf077c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924979,
-    "wof:lastmodified":1690924943,
+    "wof:lastmodified":1695886497,
     "wof:name":"Yafa'a",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/499/9/1091924999.geojson
+++ b/data/109/192/499/9/1091924999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018799,
-    "geom:area_square_m":225832614.297342,
+    "geom:area_square_m":225832614.297352,
     "geom:bbox":"45.0018721002,13.6361192702,45.2573780987,13.8107652759",
     "geom:latitude":13.711417,
     "geom:longitude":45.144278,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.LA.YR",
         "wd:id":"Q4117470"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893200,
-    "wof:geomhash":"5f39f01eed6512f66bacede332f2b3d7",
+    "wof:geomhash":"49e9bdef04620c7aeb68b3a5944dc671",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091924999,
-    "wof:lastmodified":1566660257,
+    "wof:lastmodified":1695886497,
     "wof:name":"Yahr",
     "wof:parent_id":85680985,
     "wof:placetype":"county",

--- a/data/109/192/502/5/1091925025.geojson
+++ b/data/109/192/502/5/1091925025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053433,
-    "geom:area_square_m":639037094.76612,
+    "geom:area_square_m":639037153.694999,
     "geom:bbox":"45.259969,14.575468,45.523637,14.859324",
     "geom:latitude":14.713479,
     "geom:longitude":45.385541,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.AB",
         "wd:id":"Q4117555"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893201,
-    "wof:geomhash":"fd1043de4df6ba70f1d6ab854a09fd33",
+    "wof:geomhash":"5d3fcca1f803ccd375fa5847bfe558d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925025,
-    "wof:lastmodified":1690924918,
+    "wof:lastmodified":1695886491,
     "wof:name":"Al Abdiyah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/504/9/1091925049.geojson
+++ b/data/109/192/504/9/1091925049.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.088128,
-    "geom:area_square_m":1051808748.803365,
+    "geom:area_square_m":1051808809.003502,
     "geom:bbox":"45.071919,14.938394,45.505226,15.314011",
     "geom:latitude":15.157455,
     "geom:longitude":45.28265,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.JU",
         "wd:id":"Q4117643"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893202,
-    "wof:geomhash":"d053d1a7f13bb44eb1a01e705e786ddb",
+    "wof:geomhash":"29e9611da18d58749f6caeeb4a82c5c8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925049,
-    "wof:lastmodified":1690924924,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Jubah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/506/5/1091925065.geojson
+++ b/data/109/192/506/5/1091925065.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015425,
-    "geom:area_square_m":183886833.642501,
+    "geom:area_square_m":183886912.774826,
     "geom:bbox":"44.686647,15.318671,44.807287,15.47322",
     "geom:latitude":15.395109,
     "geom:longitude":44.745812,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.MA.BI",
         "wd:id":"Q4117653"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893203,
-    "wof:geomhash":"950fe15d0bce041cd33726625a227377",
+    "wof:geomhash":"c638b929c13771b24ded295fca4cceca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925065,
-    "wof:lastmodified":1690924973,
+    "wof:lastmodified":1695886504,
     "wof:name":"Bidbadah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/507/9/1091925079.geojson
+++ b/data/109/192/507/9/1091925079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.070086,
-    "geom:area_square_m":837357180.072356,
+    "geom:area_square_m":837357063.038572,
     "geom:bbox":"45.157884,14.724679,45.577848,15.153297",
     "geom:latitude":14.932901,
     "geom:longitude":45.381101,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.HA",
         "wd:id":"Q4117540"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893204,
-    "wof:geomhash":"a662d278305c8b9d8850858e52d5c3a2",
+    "wof:geomhash":"2269644cb25d153a0b24568f7fcf2469",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925079,
-    "wof:lastmodified":1690924978,
+    "wof:lastmodified":1695886235,
     "wof:name":"Harib",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/510/7/1091925107.geojson
+++ b/data/109/192/510/7/1091925107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.014375,
-    "geom:area_square_m":171314043.72754,
+    "geom:area_square_m":171314043.727538,
     "geom:bbox":"44.5162585049,15.4048020615,44.7165139416,15.5395677152",
     "geom:latitude":15.461649,
     "geom:longitude":44.619802,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.MA.HQ",
         "wd:id":"Q4117533"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893205,
-    "wof:geomhash":"9bc1ab0980ca95b794b0e3d8842940e8",
+    "wof:geomhash":"cacafd65740d319c70ba17386f9031a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925107,
-    "wof:lastmodified":1566660263,
+    "wof:lastmodified":1695886500,
     "wof:name":"Harib Al Qaramish",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/512/9/1091925129.geojson
+++ b/data/109/192/512/9/1091925129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.011437,
-    "geom:area_square_m":136567929.279635,
+    "geom:area_square_m":136567929.279684,
     "geom:bbox":"45.1209171928,14.9873511399,45.2520178035,15.1105111061",
     "geom:latitude":15.047341,
     "geom:longitude":45.184822,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.MA.JM",
         "wd:id":"Q4117618"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893206,
-    "wof:geomhash":"d69775853ef8dd740fb4ae4115edb7d5",
+    "wof:geomhash":"2cfaabd1118fc6e6702975a898e807c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925129,
-    "wof:lastmodified":1566660294,
+    "wof:lastmodified":1695886513,
     "wof:name":"Jabal Murad",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/515/5/1091925155.geojson
+++ b/data/109/192/515/5/1091925155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.053816,
-    "geom:area_square_m":643736637.095366,
+    "geom:area_square_m":643736637.095452,
     "geom:bbox":"45.0498631698,14.5049663341,45.3172565851,14.8603364368",
     "geom:latitude":14.673561,
     "geom:longitude":45.160395,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.ML",
         "wd:id":"Q4117604"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893207,
-    "wof:geomhash":"6f254a058dd1be64b27c88b020952bf0",
+    "wof:geomhash":"6507b522ca4fc3b4ae088277c1a97f13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925155,
-    "wof:lastmodified":1566660294,
+    "wof:lastmodified":1695886513,
     "wof:name":"Mahliyah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/517/5/1091925175.geojson
+++ b/data/109/192/517/5/1091925175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.103805,
-    "geom:area_square_m":1234721892.074991,
+    "geom:area_square_m":1234721892.075048,
     "geom:bbox":"44.5770728688,15.6243021783,45.0129328659,16.0334745648",
     "geom:latitude":15.856599,
     "geom:longitude":44.79701,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.MJ",
         "wd:id":"Q4117576"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893209,
-    "wof:geomhash":"ccee122d40ce7128e65fc9260da7bdab",
+    "wof:geomhash":"1aa55611cd69a34ed6325fddc7bb47b8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925175,
-    "wof:lastmodified":1566660263,
+    "wof:lastmodified":1695886500,
     "wof:name":"Majzar",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/519/9/1091925199.geojson
+++ b/data/109/192/519/9/1091925199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.773663,
-    "geom:area_square_m":9210358887.986536,
+    "geom:area_square_m":9210359138.723995,
     "geom:bbox":"45.209863,15.082354,46.803467,16.160865",
     "geom:latitude":15.681239,
     "geom:longitude":45.894161,
@@ -73,9 +73,10 @@
     "wof:concordances":{
         "hasc:id":"YE.MA.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893210,
-    "wof:geomhash":"d4dd2089ded8b645a7191b465c06632e",
+    "wof:geomhash":"44910f3f7688c3e78b9c246963609a55",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1091925199,
-    "wof:lastmodified":1636497422,
+    "wof:lastmodified":1695886735,
     "wof:name":"Marib",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/522/1/1091925221.geojson
+++ b/data/109/192/522/1/1091925221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010412,
-    "geom:area_square_m":124112299.962737,
+    "geom:area_square_m":124112166.808458,
     "geom:bbox":"45.226292,15.351578,45.381451,15.479063",
     "geom:latitude":15.417264,
     "geom:longitude":45.301561,
@@ -204,9 +204,10 @@
         "hasc:id":"YE.MA.MC",
         "wd:id":"Q335478"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893211,
-    "wof:geomhash":"cb89f4dbb622b6c0891f7cb0ea8b6468",
+    "wof:geomhash":"1276a1f21550b8207fc39d2c5a718ebd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -216,7 +217,7 @@
         }
     ],
     "wof:id":1091925221,
-    "wof:lastmodified":1690925016,
+    "wof:lastmodified":1695886512,
     "wof:name":"Marib City",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/524/5/1091925245.geojson
+++ b/data/109/192/524/5/1091925245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051961,
-    "geom:area_square_m":618755084.419019,
+    "geom:area_square_m":618755084.418975,
     "geom:bbox":"44.7921556841,15.5301087109,45.2196874996,15.7443342437",
     "geom:latitude":15.629833,
     "geom:longitude":45.021803,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.ME",
         "wd:id":"Q4117580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893212,
-    "wof:geomhash":"8e20eeb5b593d9636d15b7902997a236",
+    "wof:geomhash":"8449fd1142c9e190b8866bcecd30cce1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925245,
-    "wof:lastmodified":1566660293,
+    "wof:lastmodified":1695886513,
     "wof:name":"Medghal",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/525/7/1091925257.geojson
+++ b/data/109/192/525/7/1091925257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0468,
-    "geom:area_square_m":556893753.808771,
+    "geom:area_square_m":556893753.80872,
     "geom:bbox":"44.9059050789,15.6644518476,45.2356162003,15.915728599",
     "geom:latitude":15.774599,
     "geom:longitude":45.075609,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.MA.RG",
         "wd:id":"Q4117603"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893213,
-    "wof:geomhash":"e1454ad393931acec13984d9822fc9c2",
+    "wof:geomhash":"05c9dc436593dd2316cb88b47a250c5a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925257,
-    "wof:lastmodified":1566660291,
+    "wof:lastmodified":1695886512,
     "wof:name":"Raghwan",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/527/7/1091925277.geojson
+++ b/data/109/192/527/7/1091925277.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064246,
-    "geom:area_square_m":767575264.633533,
+    "geom:area_square_m":767575207.435568,
     "geom:bbox":"44.907665,14.79226,45.271327,15.110885",
     "geom:latitude":14.936922,
     "geom:longitude":45.0695,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.MA.RB",
         "wd:id":"Q4117567"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893214,
-    "wof:geomhash":"e7ab009aad55e06cefb8f9024e8aaf2e",
+    "wof:geomhash":"3c95c9af0aeddd5d55cdb72116e0316f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925277,
-    "wof:lastmodified":1690924963,
+    "wof:lastmodified":1695886501,
     "wof:name":"Rahabah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/530/1/1091925301.geojson
+++ b/data/109/192/530/1/1091925301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116106,
-    "geom:area_square_m":1383804224.974152,
+    "geom:area_square_m":1383804586.760776,
     "geom:bbox":"44.703232,15.284636,45.318414,15.588103",
     "geom:latitude":15.448783,
     "geom:longitude":45.030756,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.MA.SI",
         "wd:id":"Q4117559"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893215,
-    "wof:geomhash":"0d81d619d84b10fc7f639e7a98c99619",
+    "wof:geomhash":"e0fc48720c3e6c60bc8253714efb2814",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925301,
-    "wof:lastmodified":1690924971,
+    "wof:lastmodified":1695886503,
     "wof:name":"Sirwah",
     "wof:parent_id":85681015,
     "wof:placetype":"county",

--- a/data/109/192/530/3/1091925303.geojson
+++ b/data/109/192/530/3/1091925303.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.02945,
-    "geom:area_square_m":352232758.890281,
+    "geom:area_square_m":352232609.536345,
     "geom:bbox":"43.470003,14.592843,43.768582,14.784852",
     "geom:latitude":14.698328,
     "geom:longitude":43.609196,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.RM.JB",
         "wd:id":"Q4117615"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893216,
-    "wof:geomhash":"40a6883782ed7f46c3222f10292d4e64",
+    "wof:geomhash":"c0d7884f84a8f348a390df687c5763f6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925303,
-    "wof:lastmodified":1690924972,
+    "wof:lastmodified":1695886503,
     "wof:name":"Al Jabin",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/530/5/1091925305.geojson
+++ b/data/109/192/530/5/1091925305.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023446,
-    "geom:area_square_m":280663924.628223,
+    "geom:area_square_m":280663914.540512,
     "geom:bbox":"43.507568,14.369233,43.656387,14.656963",
     "geom:latitude":14.511839,
     "geom:longitude":43.573133,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.RM.JF",
         "wd:id":"Q4117518"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893218,
-    "wof:geomhash":"fd36523f07c909e2ff94592bc086e112",
+    "wof:geomhash":"13d04348554edac81f3b294894983c70",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925305,
-    "wof:lastmodified":1690924972,
+    "wof:lastmodified":1695886503,
     "wof:name":"Al Jafariyah",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/530/7/1091925307.geojson
+++ b/data/109/192/530/7/1091925307.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031814,
-    "geom:area_square_m":380549473.334668,
+    "geom:area_square_m":380549651.491877,
     "geom:bbox":"43.706554,14.532836,43.934272,14.841537",
     "geom:latitude":14.674538,
     "geom:longitude":43.821346,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.RM.SA",
         "wd:id":"Q4118313"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893219,
-    "wof:geomhash":"b98371e40464551c71b2b0fa23cb30c8",
+    "wof:geomhash":"d6e1e1c08a84ceeac615e7d2221282cc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091925307,
-    "wof:lastmodified":1690924971,
+    "wof:lastmodified":1695886503,
     "wof:name":"As Salafiyah",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/530/9/1091925309.geojson
+++ b/data/109/192/530/9/1091925309.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034562,
-    "geom:area_square_m":413122743.431053,
+    "geom:area_square_m":413122799.833773,
     "geom:bbox":"43.467794,14.72784,43.745059,14.950279",
     "geom:latitude":14.832192,
     "geom:longitude":43.595139,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.RM.BA",
         "wd:id":"Q4117553"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893220,
-    "wof:geomhash":"289ce63597c07d20e1d6ca47720342ee",
+    "wof:geomhash":"3bd88fe10263939594f51bcbb85c7c7d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925309,
-    "wof:lastmodified":1690924970,
+    "wof:lastmodified":1695886503,
     "wof:name":"Bilad At Ta'am",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/533/1/1091925331.geojson
+++ b/data/109/192/533/1/1091925331.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017666,
-    "geom:area_square_m":211448753.414411,
+    "geom:area_square_m":211448794.60592,
     "geom:bbox":"43.587822,14.450252,43.779775,14.648246",
     "geom:latitude":14.541373,
     "geom:longitude":43.66889,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.RM.KU",
         "wd:id":"Q1884237"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893221,
-    "wof:geomhash":"407876ae175c0338a80dc7c9727bf1cb",
+    "wof:geomhash":"0a8d1663c5a1fbc29e2cd12880ce7601",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091925331,
-    "wof:lastmodified":1690924917,
+    "wof:lastmodified":1695886491,
     "wof:name":"Kusmah",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/534/5/1091925345.geojson
+++ b/data/109/192/534/5/1091925345.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022103,
-    "geom:area_square_m":264515848.300941,
+    "geom:area_square_m":264516009.432069,
     "geom:bbox":"43.63432,14.467921,43.887634,14.673603",
     "geom:latitude":14.574196,
     "geom:longitude":43.757859,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.RM.MA",
         "wd:id":"Q4117569"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893222,
-    "wof:geomhash":"f283f8651e1107d337081d6782260490",
+    "wof:geomhash":"b8e119b4b040a8962e3f757b416dd1a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925345,
-    "wof:lastmodified":1690924917,
+    "wof:lastmodified":1695886491,
     "wof:name":"Mazhar",
     "wof:parent_id":85681033,
     "wof:placetype":"county",

--- a/data/109/192/536/5/1091925365.geojson
+++ b/data/109/192/536/5/1091925365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017908,
-    "geom:area_square_m":212067950.510145,
+    "geom:area_square_m":212067973.410007,
     "geom:bbox":"43.211667,16.610551,43.339886,16.853908",
     "geom:latitude":16.730137,
     "geom:longitude":43.282817,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SD.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893225,
-    "wof:geomhash":"852a51fae6fcd72eff133e6e3bd593a1",
+    "wof:geomhash":"b806a066fd7c5fbb62b18814452c724f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091925365,
-    "wof:lastmodified":1627523011,
+    "wof:lastmodified":1695886233,
     "wof:name":"Al Dhaher",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/539/1/1091925391.geojson
+++ b/data/109/192/539/1/1091925391.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03626,
-    "geom:area_square_m":428992589.912507,
+    "geom:area_square_m":428992454.452255,
     "geom:bbox":"44.098258,16.708893,44.447607,17.067826",
     "geom:latitude":16.904466,
     "geom:longitude":44.262709,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.SD.HW",
         "wd:id":"Q4117593"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893226,
-    "wof:geomhash":"82d88309765255c272ca925d17ebc7eb",
+    "wof:geomhash":"e0ce998083b5be8d3743c6529c57a9c5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925391,
-    "wof:lastmodified":1690924973,
+    "wof:lastmodified":1695886503,
     "wof:name":"Al Hashwah",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/541/5/1091925415.geojson
+++ b/data/109/192/541/5/1091925415.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137195,
-    "geom:area_square_m":1622204644.126327,
+    "geom:area_square_m":1622204904.650218,
     "geom:bbox":"43.61486,16.650357,44.102621,17.375",
     "geom:latitude":17.010861,
     "geom:longitude":43.838137,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.SD.SF",
         "wd:id":"Q4117492"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893227,
-    "wof:geomhash":"ccb0df4ebccfb1c9f8c604b23c460516",
+    "wof:geomhash":"becb36be50dd3b8bf90f67d68b24d410",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925415,
-    "wof:lastmodified":1690925017,
+    "wof:lastmodified":1695886512,
     "wof:name":"As Safra",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/541/7/1091925417.geojson
+++ b/data/109/192/541/7/1091925417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.091373,
-    "geom:area_square_m":1078228254.924185,
+    "geom:area_square_m":1078228119.022051,
     "geom:bbox":"43.24075,17.191625,43.68596,17.565833",
     "geom:latitude":17.385341,
     "geom:longitude":43.490982,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.SD.BA",
         "wd:id":"Q4117547"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893229,
-    "wof:geomhash":"a296c4eec1c7367b833374e32ca4cfab",
+    "wof:geomhash":"718088ff66782e47a488347b61b1f551",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925417,
-    "wof:lastmodified":1690925016,
+    "wof:lastmodified":1695886513,
     "wof:name":"Baqim",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/541/9/1091925419.geojson
+++ b/data/109/192/541/9/1091925419.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.0114,
-    "geom:area_square_m":134813847.658773,
+    "geom:area_square_m":134813888.422992,
     "geom:bbox":"43.231994,16.894662,43.389212,17.063146",
     "geom:latitude":16.991949,
     "geom:longitude":43.317367,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SD.GH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893230,
-    "wof:geomhash":"d9de0013b848acb886de4700b68b217c",
+    "wof:geomhash":"e2c9fae55180701072c5680a317a1e05",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091925419,
-    "wof:lastmodified":1627523012,
+    "wof:lastmodified":1695886234,
     "wof:name":"Ghamr",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/542/5/1091925425.geojson
+++ b/data/109/192/542/5/1091925425.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047865,
-    "geom:area_square_m":566851491.932653,
+    "geom:area_square_m":566851657.205731,
     "geom:bbox":"43.305509,16.609793,43.664957,16.846181",
     "geom:latitude":16.713663,
     "geom:longitude":43.456409,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SD.HD",
         "wd:id":"Q4117573"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893231,
-    "wof:geomhash":"ac0720c525d97ec0722a6ed0ba7d6a0a",
+    "wof:geomhash":"e41060c3da2dfa4c2c716f3361da9669",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925425,
-    "wof:lastmodified":1690924967,
+    "wof:lastmodified":1695886502,
     "wof:name":"Haydan",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/542/7/1091925427.geojson
+++ b/data/109/192/542/7/1091925427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.44219,
-    "geom:area_square_m":5223980963.939883,
+    "geom:area_square_m":5223981294.840139,
     "geom:bbox":"43.902242,16.730955,44.890749,17.43353",
     "geom:latitude":17.173145,
     "geom:longitude":44.345596,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SD.KB",
         "wd:id":"Q4117637"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893232,
-    "wof:geomhash":"ab646b06e452021a9492fb1f149afb8c",
+    "wof:geomhash":"ef34047fd51fb86713a506b15e528300",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925427,
-    "wof:lastmodified":1690924966,
+    "wof:lastmodified":1695886502,
     "wof:name":"Kitaf wa Al Boqe'e",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/544/5/1091925445.geojson
+++ b/data/109/192/544/5/1091925445.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.078055,
-    "geom:area_square_m":922472708.735493,
+    "geom:area_square_m":922472482.627404,
     "geom:bbox":"43.322123,16.939729,43.698606,17.243946",
     "geom:latitude":17.105113,
     "geom:longitude":43.499424,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SD.MA",
         "wd:id":"Q4117546"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893234,
-    "wof:geomhash":"1e5e07d3310ef3fb88d8e8315556bf44",
+    "wof:geomhash":"7936156cd33350ef2a2093c916d7d75e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925445,
-    "wof:lastmodified":1690924962,
+    "wof:lastmodified":1695886501,
     "wof:name":"Majz",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/545/7/1091925457.geojson
+++ b/data/109/192/545/7/1091925457.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038312,
-    "geom:area_square_m":452602588.443398,
+    "geom:area_square_m":452602417.865269,
     "geom:bbox":"43.151947,17.035685,43.401533,17.304374",
     "geom:latitude":17.176624,
     "geom:longitude":43.274157,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.SD.MO",
         "wd:id":"Q4117482"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893235,
-    "wof:geomhash":"177da77763f54be8dbafcf661ab5c7e3",
+    "wof:geomhash":"99894819a79fb11b771b8a2158eae2dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091925457,
-    "wof:lastmodified":1690924966,
+    "wof:lastmodified":1695886502,
     "wof:name":"Monabbih",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/547/9/1091925479.geojson
+++ b/data/109/192/547/9/1091925479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016172,
-    "geom:area_square_m":190859538.685571,
+    "geom:area_square_m":190859781.771764,
     "geom:bbox":"43.228028,17.216541,43.434969,17.456976",
     "geom:latitude":17.360029,
     "geom:longitude":43.324626,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SD.QA",
         "wd:id":"Q283304"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893236,
-    "wof:geomhash":"135c60dd6f7ada4bd7a628e4f383c136",
+    "wof:geomhash":"6d601ecc63aa84c27a8ca46bdc8324fc",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925479,
-    "wof:lastmodified":1690925012,
+    "wof:lastmodified":1695886512,
     "wof:name":"Qatabir",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/549/7/1091925497.geojson
+++ b/data/109/192/549/7/1091925497.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019651,
-    "geom:area_square_m":232465637.185615,
+    "geom:area_square_m":232465180.025229,
     "geom:bbox":"43.177445,16.817768,43.324191,17.029528",
     "geom:latitude":16.927219,
     "geom:longitude":43.254721,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.SD.RA",
         "wd:id":"Q4117523"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893237,
-    "wof:geomhash":"243a9de459c9407817e8ffa627fb20fb",
+    "wof:geomhash":"cbd4cab489d220196f2ebe7538019567",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091925497,
-    "wof:lastmodified":1690925010,
+    "wof:lastmodified":1695886511,
     "wof:name":"Razih",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/552/5/1091925525.geojson
+++ b/data/109/192/552/5/1091925525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002368,
-    "geom:area_square_m":28014427.873643,
+    "geom:area_square_m":28014568.86152,
     "geom:bbox":"43.73667,16.881782,43.781501,16.953062",
     "geom:latitude":16.917439,
     "geom:longitude":43.761587,
@@ -99,9 +99,10 @@
         "hasc:id":"YE.SD.SD",
         "wd:id":"Q4117548"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893238,
-    "wof:geomhash":"37087d583f84aa833b09ddf5ef0fbf29",
+    "wof:geomhash":"483329b9331974356771fbb0808a2ca2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1091925525,
-    "wof:lastmodified":1690924975,
+    "wof:lastmodified":1695886504,
     "wof:name":"Sa'adah",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/555/1/1091925551.geojson
+++ b/data/109/192/555/1/1091925551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.063164,
-    "geom:area_square_m":747373854.91001,
+    "geom:area_square_m":747373581.40915,
     "geom:bbox":"43.572756,16.653637,43.793426,17.114484",
     "geom:latitude":16.883396,
     "geom:longitude":43.6864,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.SD.SR",
         "wd:id":"Q1884209"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893240,
-    "wof:geomhash":"904ce5dcad7d5c7026a02a81c83a2bed",
+    "wof:geomhash":"f49d0a6cc61d06d48f506104f81f79b9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091925551,
-    "wof:lastmodified":1690924974,
+    "wof:lastmodified":1695886504,
     "wof:name":"Sahar",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/557/3/1091925573.geojson
+++ b/data/109/192/557/3/1091925573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045402,
-    "geom:area_square_m":537248299.19334,
+    "geom:area_square_m":537248589.257339,
     "geom:bbox":"43.317378,16.736865,43.623812,16.983734",
     "geom:latitude":16.868635,
     "geom:longitude":43.48228,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SD.SQ",
         "wd:id":"Q4117500"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893241,
-    "wof:geomhash":"9b04a0901987e4a7525fee51b1997ca8",
+    "wof:geomhash":"f5fee08b2ee5617e8a96269a4da681ce",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925573,
-    "wof:lastmodified":1690924923,
+    "wof:lastmodified":1695886492,
     "wof:name":"Saqayn",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/559/5/1091925595.geojson
+++ b/data/109/192/559/5/1091925595.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005927,
-    "geom:area_square_m":70126612.706728,
+    "geom:area_square_m":70126833.068633,
     "geom:bbox":"43.137924,16.838854,43.234436,16.944362",
     "geom:latitude":16.892482,
     "geom:longitude":43.186408,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SD.SH",
         "wd:id":"Q4117551"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893242,
-    "wof:geomhash":"6ceefa7e37cb0cd9253c19f3c3e0a16e",
+    "wof:geomhash":"c6a4616aa696ea9cfacd471a1574085c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925595,
-    "wof:lastmodified":1690924921,
+    "wof:lastmodified":1695886492,
     "wof:name":"Shada'a",
     "wof:parent_id":85680955,
     "wof:placetype":"county",

--- a/data/109/192/561/5/1091925615.geojson
+++ b/data/109/192/561/5/1091925615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038904,
-    "geom:area_square_m":464063493.88756,
+    "geom:area_square_m":464063493.887545,
     "geom:bbox":"43.70806532,15.1585100444,43.9703820764,15.3845088092",
     "geom:latitude":15.273027,
     "geom:longitude":43.849415,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.NA.HD",
         "wd:id":"Q4118988"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893243,
-    "wof:geomhash":"f01ebdc1fe10be49b6a4f9c44a3e9bc4",
+    "wof:geomhash":"78bed90f69bdb3e069f79f5e2876dba1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091925615,
-    "wof:lastmodified":1566660246,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Haymah Ad Dakhiliyah",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/563/7/1091925637.geojson
+++ b/data/109/192/563/7/1091925637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.058312,
-    "geom:area_square_m":696413758.026098,
+    "geom:area_square_m":696413758.026001,
     "geom:bbox":"43.7171787754,14.840675815,43.9804067069,15.2125012937",
     "geom:latitude":15.0168,
     "geom:longitude":43.86383,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.NA.HK",
         "wd:id":"Q4117232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893244,
-    "wof:geomhash":"1e961cd20ac370828b2e5d5bf3aef8ee",
+    "wof:geomhash":"bd5e58b9d66d845ca92461babac3a7db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091925637,
-    "wof:lastmodified":1566660274,
+    "wof:lastmodified":1695886504,
     "wof:name":"Al Haymah Al Kharijiyah",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/566/7/1091925667.geojson
+++ b/data/109/192/566/7/1091925667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031082,
-    "geom:area_square_m":371196080.04219,
+    "geom:area_square_m":371196066.501991,
     "geom:bbox":"44.358889,14.936381,44.646602,15.106163",
     "geom:latitude":15.023007,
     "geom:longitude":44.479725,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.HU",
         "wd:id":"Q4117303"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893245,
-    "wof:geomhash":"ecdc302a0e3d83784800ea18c4372a1f",
+    "wof:geomhash":"eb33c4bdb394b39aa1afbfe6bee932a4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925667,
-    "wof:lastmodified":1690924920,
+    "wof:lastmodified":1695886492,
     "wof:name":"Al Husn",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/569/5/1091925695.geojson
+++ b/data/109/192/569/5/1091925695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.107463,
-    "geom:area_square_m":1278629255.694982,
+    "geom:area_square_m":1278629062.344614,
     "geom:bbox":"44.097595,15.553221,44.399254,16.045959",
     "geom:latitude":15.794747,
     "geom:longitude":44.260647,
@@ -86,9 +86,10 @@
         "hasc:id":"YE.NA.AR",
         "wd:id":"Q4117519"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893246,
-    "wof:geomhash":"1269d5f85a570f681d3cd166e5f0a71e",
+    "wof:geomhash":"7facf6378a191dfa50611178c3d11131",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1091925695,
-    "wof:lastmodified":1690924916,
+    "wof:lastmodified":1695886492,
     "wof:name":"Arhab",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/571/9/1091925719.geojson
+++ b/data/109/192/571/9/1091925719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.035741,
-    "geom:area_square_m":426188375.054498,
+    "geom:area_square_m":426188370.253423,
     "geom:bbox":"44.383728,15.047969,44.691752,15.478934",
     "geom:latitude":15.343903,
     "geom:longitude":44.551262,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.NA.AT",
         "wd:id":"Q4117335"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893247,
-    "wof:geomhash":"10594c7f7fbc5aa50f17771e077e59fc",
+    "wof:geomhash":"b48615222d0519351c350f6fe26d22aa",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925719,
-    "wof:lastmodified":1690925011,
+    "wof:lastmodified":1695886511,
     "wof:name":"Attyal",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/573/7/1091925737.geojson
+++ b/data/109/192/573/7/1091925737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.147054,
-    "geom:area_square_m":1755763223.949184,
+    "geom:area_square_m":1755763324.156456,
     "geom:bbox":"44.632752,14.747906,45.108608,15.350595",
     "geom:latitude":15.076311,
     "geom:longitude":44.873186,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.BD",
         "wd:id":"Q4117374"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893248,
-    "wof:geomhash":"3298126ca6d8044ca68cbf9ec3ff4ab4",
+    "wof:geomhash":"63ddd6dd71389987e4be3d96fa3b3542",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925737,
-    "wof:lastmodified":1690924969,
+    "wof:lastmodified":1695886503,
     "wof:name":"Bani Dhabyan",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/575/9/1091925759.geojson
+++ b/data/109/192/575/9/1091925759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031963,
-    "geom:area_square_m":380945779.152965,
+    "geom:area_square_m":380945485.066184,
     "geom:bbox":"44.230384,15.344343,44.525503,15.556383",
     "geom:latitude":15.45298,
     "geom:longitude":44.354501,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.BH",
         "wd:id":"Q4117336"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893249,
-    "wof:geomhash":"9b0e6c1edf4711ef6e6b52b373c57203",
+    "wof:geomhash":"dff191e619b507d8b5ae7b490f4c2796",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925759,
-    "wof:lastmodified":1690924961,
+    "wof:lastmodified":1695886501,
     "wof:name":"Bani Hushaysh",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/578/7/1091925787.geojson
+++ b/data/109/192/578/7/1091925787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.095017,
-    "geom:area_square_m":1133777328.489149,
+    "geom:area_square_m":1133777329.994529,
     "geom:bbox":"43.86767,14.933869,44.229836,15.49699",
     "geom:latitude":15.202918,
     "geom:longitude":44.05359,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.BM",
         "wd:id":"Q4117326"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893250,
-    "wof:geomhash":"d8e235b3f7d41526c6bd60aac5497120",
+    "wof:geomhash":"ef802fda4c6f49f632e8d3ef058ed0b3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925787,
-    "wof:lastmodified":1690925011,
+    "wof:lastmodified":1695886511,
     "wof:name":"Bani Matar",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/579/5/1091925795.geojson
+++ b/data/109/192/579/5/1091925795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033556,
-    "geom:area_square_m":400736530.587083,
+    "geom:area_square_m":400736469.243959,
     "geom:bbox":"44.136565,14.92586,44.364337,15.143963",
     "geom:latitude":15.027052,
     "geom:longitude":44.258864,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.BR",
         "wd:id":"Q4907490"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893251,
-    "wof:geomhash":"101c9e82c28da479248726983f002c8c",
+    "wof:geomhash":"e19f8552b391b825de4889c2010531fb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925795,
-    "wof:lastmodified":1690925018,
+    "wof:lastmodified":1695886513,
     "wof:name":"Bilad Ar Rus",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/579/7/1091925797.geojson
+++ b/data/109/192/579/7/1091925797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.048579,
-    "geom:area_square_m":578847339.952379,
+    "geom:area_square_m":578847398.769282,
     "geom:bbox":"43.902743,15.344792,44.209848,15.642812",
     "geom:latitude":15.496744,
     "geom:longitude":44.060746,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.HA",
         "wd:id":"Q4117299"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893253,
-    "wof:geomhash":"a3d3ed0a0e6a2558d1901dda261e1766",
+    "wof:geomhash":"bb09edce2a766b938b027ef672ac6493",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925797,
-    "wof:lastmodified":1690925018,
+    "wof:lastmodified":1695886513,
     "wof:name":"Hamdan",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/579/9/1091925799.geojson
+++ b/data/109/192/579/9/1091925799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046506,
-    "geom:area_square_m":554968675.834658,
+    "geom:area_square_m":554968912.368288,
     "geom:bbox":"44.386702,15.060545,44.650045,15.329187",
     "geom:latitude":15.19014,
     "geom:longitude":44.502403,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.JI",
         "wd:id":"Q4117339"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893254,
-    "wof:geomhash":"c9067fdbdc4c988bc48a89b3ab81c043",
+    "wof:geomhash":"b55abd88533ea06a5faad41729cac304",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925799,
-    "wof:lastmodified":1690925017,
+    "wof:lastmodified":1695886513,
     "wof:name":"Jihanah",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/580/3/1091925803.geojson
+++ b/data/109/192/580/3/1091925803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050141,
-    "geom:area_square_m":598086422.117426,
+    "geom:area_square_m":598086332.563581,
     "geom:bbox":"44.569757,15.133955,44.967464,15.413942",
     "geom:latitude":15.279259,
     "geom:longitude":44.750185,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.NA.KH",
         "wd:id":"Q4117301"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893255,
-    "wof:geomhash":"6a6bdda5a4745c3b7e7077bed2dd5e9d",
+    "wof:geomhash":"7044d8ed50ba00dec0fe5207e8090cf2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925803,
-    "wof:lastmodified":1690924968,
+    "wof:lastmodified":1695886502,
     "wof:name":"Khwlan",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/581/1/1091925811.geojson
+++ b/data/109/192/581/1/1091925811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.059134,
-    "geom:area_square_m":705968557.959559,
+    "geom:area_square_m":705968163.442625,
     "geom:bbox":"43.541443,14.858223,43.829906,15.284434",
     "geom:latitude":15.095059,
     "geom:longitude":43.696634,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.NA.MA",
         "wd:id":"Q1010798"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893256,
-    "wof:geomhash":"423e9e616312208b08fb10db981b5038",
+    "wof:geomhash":"62b26384bef4ad55ea9b463e610d6e13",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091925811,
-    "wof:lastmodified":1690924960,
+    "wof:lastmodified":1695886501,
     "wof:name":"Manakhah",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/582/9/1091925829.geojson
+++ b/data/109/192/582/9/1091925829.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155542,
-    "geom:area_square_m":1851210964.633797,
+    "geom:area_square_m":1851211296.729617,
     "geom:bbox":"44.350245,15.473698,44.797854,16.031867",
     "geom:latitude":15.737485,
     "geom:longitude":44.542357,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.NI",
         "wd:id":"Q4117369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893257,
-    "wof:geomhash":"aff7e06b9809a87718c5e26a4648b435",
+    "wof:geomhash":"97cd4f60374b384dc29086a1f508399b",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925829,
-    "wof:lastmodified":1690925010,
+    "wof:lastmodified":1695886511,
     "wof:name":"Nihm",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/584/9/1091925849.geojson
+++ b/data/109/192/584/9/1091925849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01459,
-    "geom:area_square_m":174215153.867798,
+    "geom:area_square_m":174215139.830231,
     "geom:bbox":"43.506874,14.991912,43.659391,15.151044",
     "geom:latitude":15.062755,
     "geom:longitude":43.588865,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.NA.SF",
         "wd:id":"Q4117236"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893259,
-    "wof:geomhash":"2daf9d17a92e3c726e2732f2150a701a",
+    "wof:geomhash":"403fc36a08cf955d57f365cef7d2e585",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925849,
-    "wof:lastmodified":1690925019,
+    "wof:lastmodified":1695886513,
     "wof:name":"Sa'fan",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/587/5/1091925875.geojson
+++ b/data/109/192/587/5/1091925875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.049584,
-    "geom:area_square_m":591562976.212225,
+    "geom:area_square_m":591562627.670824,
     "geom:bbox":"44.160045,15.07009,44.451364,15.379734",
     "geom:latitude":15.237469,
     "geom:longitude":44.316587,
@@ -89,9 +89,10 @@
         "hasc:id":"YE.NA.SN",
         "wd:id":"Q4117320"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893260,
-    "wof:geomhash":"1d835b3dc5e6526625242ad7db34c767",
+    "wof:geomhash":"c9b794f4e5895748858e14ed281aa501",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1091925875,
-    "wof:lastmodified":1690924968,
+    "wof:lastmodified":1695886502,
     "wof:name":"Sanhan",
     "wof:parent_id":85681021,
     "wof:placetype":"county",

--- a/data/109/192/590/3/1091925903.geojson
+++ b/data/109/192/590/3/1091925903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064025,
-    "geom:area_square_m":764932283.454281,
+    "geom:area_square_m":764932038.264608,
     "geom:bbox":"45.475895,14.70883,45.725249,15.188441",
     "geom:latitude":14.934649,
     "geom:longitude":45.599796,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.AI",
         "wd:id":"Q4117782"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893261,
-    "wof:geomhash":"cebc3fe39fd1de1cb84e5485850f0bd0",
+    "wof:geomhash":"ef89332ba1d474e8928b6092d900d751",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925903,
-    "wof:lastmodified":1690924976,
+    "wof:lastmodified":1695886504,
     "wof:name":"Ain",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/592/9/1091925929.geojson
+++ b/data/109/192/592/9/1091925929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.192447,
-    "geom:area_square_m":2297818315.894993,
+    "geom:area_square_m":2297818396.692344,
     "geom:bbox":"47.037395,14.796348,47.664008,15.36982",
     "geom:latitude":15.067929,
     "geom:longitude":47.38648,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SH.TA",
         "wd:id":"Q4117694"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893262,
-    "wof:geomhash":"ca15ec0b1f0270444a480404ac9c3793",
+    "wof:geomhash":"9a2bce48208dd32cbc4c54fe6cde3b69",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925929,
-    "wof:lastmodified":1690924921,
+    "wof:lastmodified":1695886493,
     "wof:name":"Al Talh",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/594/7/1091925947.geojson
+++ b/data/109/192/594/7/1091925947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.197861,
-    "geom:area_square_m":2367852716.080299,
+    "geom:area_square_m":2367852468.340199,
     "geom:bbox":"46.956436,14.155692,47.591325,14.839306",
     "geom:latitude":14.574581,
     "geom:longitude":47.278478,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SH.RA",
         "wd:id":"Q10734682"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893263,
-    "wof:geomhash":"655a843d831b6a4ebc156b21f5a3217e",
+    "wof:geomhash":"6541ceeb9c6b5442bc6215df96891245",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091925947,
-    "wof:lastmodified":1690924916,
+    "wof:lastmodified":1695886492,
     "wof:name":"Ar Rawdah",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/597/1/1091925971.geojson
+++ b/data/109/192/597/1/1091925971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.306664,
-    "geom:area_square_m":3654911754.04703,
+    "geom:area_square_m":3654911754.047153,
     "geom:bbox":"46.7703197042,15.1062650876,47.6891189143,15.7199980622",
     "geom:latitude":15.450218,
     "geom:longitude":47.138904,
@@ -112,9 +112,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SH.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893264,
-    "wof:geomhash":"fa29e186769d7e947514d19ca5b941fd",
+    "wof:geomhash":"b7be2f620182fbe4399bfbe00bd1563f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1091925971,
-    "wof:lastmodified":1566660274,
+    "wof:lastmodified":1695886505,
     "wof:name":"Arma",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/599/7/1091925997.geojson
+++ b/data/109/192/599/7/1091925997.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072944,
-    "geom:area_square_m":874076922.977122,
+    "geom:area_square_m":874076889.261801,
     "geom:bbox":"46.690665,14.137388,47.04523,14.415498",
     "geom:latitude":14.285002,
     "geom:longitude":46.864829,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.SA",
         "wd:id":"Q4118418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893265,
-    "wof:geomhash":"72cc437455e27555679859d4e573eb79",
+    "wof:geomhash":"aa6beb7dd1dd2e0506f23151fddf6866",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091925997,
-    "wof:lastmodified":1690924976,
+    "wof:lastmodified":1695886504,
     "wof:name":"As Said",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/602/3/1091926023.geojson
+++ b/data/109/192/602/3/1091926023.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109124,
-    "geom:area_square_m":1305979993.567422,
+    "geom:area_square_m":1305980583.627759,
     "geom:bbox":"46.651113,14.367575,47.010753,14.759122",
     "geom:latitude":14.56375,
     "geom:longitude":46.827351,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.AT",
         "wd:id":"Q4118415"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893266,
-    "wof:geomhash":"541bb7c7dba71ae92612ce26d6e2361e",
+    "wof:geomhash":"462972a8799e33084bfc10de7ad2cbab",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926023,
-    "wof:lastmodified":1690924941,
+    "wof:lastmodified":1695886497,
     "wof:name":"Ataq",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/603/7/1091926037.geojson
+++ b/data/109/192/603/7/1091926037.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.064128,
-    "geom:area_square_m":766772668.358387,
+    "geom:area_square_m":766772679.992036,
     "geom:bbox":"45.584951,14.590079,45.913282,14.933431",
     "geom:latitude":14.766055,
     "geom:longitude":45.739978,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SH.BA",
         "wd:id":"Q4117801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893268,
-    "wof:geomhash":"06070a0ca233139fcb1273a243837fa5",
+    "wof:geomhash":"3405fed892153d5a52137c782f0f9b57",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091926037,
-    "wof:lastmodified":1690924948,
+    "wof:lastmodified":1695886498,
     "wof:name":"Bayhan",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/606/1/1091926061.geojson
+++ b/data/109/192/606/1/1091926061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108834,
-    "geom:area_square_m":1296753713.402093,
+    "geom:area_square_m":1296753713.402011,
     "geom:bbox":"47.3401803728,15.283696012,47.8659828114,15.7215898611",
     "geom:latitude":15.507637,
     "geom:longitude":47.581535,
@@ -139,9 +139,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SH.DH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893269,
-    "wof:geomhash":"212623097b3925a34fac8e88cf11a77d",
+    "wof:geomhash":"2c02762c3a04dbde4b5112465426c38f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -151,7 +152,7 @@
         }
     ],
     "wof:id":1091926061,
-    "wof:lastmodified":1566660286,
+    "wof:lastmodified":1695886510,
     "wof:name":"Dhar",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/608/5/1091926085.geojson
+++ b/data/109/192/608/5/1091926085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081935,
-    "geom:area_square_m":981725293.362359,
+    "geom:area_square_m":981725241.120946,
     "geom:bbox":"46.99611,14.06341,47.276229,14.513934",
     "geom:latitude":14.305038,
     "geom:longitude":47.136844,
@@ -122,9 +122,10 @@
         "hasc:id":"YE.SH.HN",
         "wd:id":"Q3125264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893271,
-    "wof:geomhash":"7710439840e5d2eacc7ead1f0f51eaf3",
+    "wof:geomhash":"c040046df2f2b5c87aa1cab017e627a9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1091926085,
-    "wof:lastmodified":1690925002,
+    "wof:lastmodified":1695886509,
     "wof:name":"Habban",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/611/1/1091926111.geojson
+++ b/data/109/192/611/1/1091926111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.054049,
-    "geom:area_square_m":647943799.173769,
+    "geom:area_square_m":647943666.065606,
     "geom:bbox":"46.282775,14.055413,46.602729,14.3087",
     "geom:latitude":14.187117,
     "geom:longitude":46.437833,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.HT",
         "wd:id":"Q4117727"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893272,
-    "wof:geomhash":"ba38c06417a3d7d6d7bef48ca096bb2c",
+    "wof:geomhash":"c9604666e7074d0f6c1b9b40e94e6bd2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926111,
-    "wof:lastmodified":1690924939,
+    "wof:lastmodified":1695886496,
     "wof:name":"Hatib",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/612/3/1091926123.geojson
+++ b/data/109/192/612/3/1091926123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54281,
-    "geom:area_square_m":6477983855.699579,
+    "geom:area_square_m":6477983528.507767,
     "geom:bbox":"46.162285,14.73046,47.301842,15.648672",
     "geom:latitude":15.170674,
     "geom:longitude":46.688294,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SH.JA",
         "wd:id":"Q4118423"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893273,
-    "wof:geomhash":"5272edc07898723044733aa01a7c0d88",
+    "wof:geomhash":"d2cd1cdeec9f19fbf87090b4b3b048f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091926123,
-    "wof:lastmodified":1690924989,
+    "wof:lastmodified":1695886507,
     "wof:name":"Jardan",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/613/7/1091926137.geojson
+++ b/data/109/192/613/7/1091926137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.230688,
-    "geom:area_square_m":2763297542.820503,
+    "geom:area_square_m":2763297480.59382,
     "geom:bbox":"47.364151,14.161491,48.116653,14.631491",
     "geom:latitude":14.366052,
     "geom:longitude":47.682333,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.MA",
         "wd:id":"Q4117822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893274,
-    "wof:geomhash":"2e0e1aed6b190e8ee5777b43323ac8e9",
+    "wof:geomhash":"fec21ea12f8161b71ffde9043fe27b96",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926137,
-    "wof:lastmodified":1690924982,
+    "wof:lastmodified":1695886505,
     "wof:name":"Mayfa'a",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/615/7/1091926157.geojson
+++ b/data/109/192/615/7/1091926157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.069872,
-    "geom:area_square_m":836448733.674272,
+    "geom:area_square_m":836448472.564054,
     "geom:bbox":"45.769424,14.324882,46.092707,14.644422",
     "geom:latitude":14.502332,
     "geom:longitude":45.942098,
@@ -92,9 +92,10 @@
         "hasc:id":"YE.SH.MU",
         "wd:id":"Q4117780"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893275,
-    "wof:geomhash":"5715bab24e4d1248da21235c98c41188",
+    "wof:geomhash":"055e18d165b01d946b39b770b1542bd9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1091926157,
-    "wof:lastmodified":1690924991,
+    "wof:lastmodified":1695886507,
     "wof:name":"Merkhah Al Ulya",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/617/5/1091926175.geojson
+++ b/data/109/192/617/5/1091926175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.298892,
-    "geom:area_square_m":3574106991.427006,
+    "geom:area_square_m":3574107234.603587,
     "geom:bbox":"45.770306,14.250923,46.544888,15.150083",
     "geom:latitude":14.746112,
     "geom:longitude":46.196564,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.SH.MS",
         "wd:id":"Q4118417"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893276,
-    "wof:geomhash":"82229461fcde1140cacd32cdab5e6792",
+    "wof:geomhash":"d2061f5ed25cb26307130c701e70cce1",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926175,
-    "wof:lastmodified":1690924930,
+    "wof:lastmodified":1695886494,
     "wof:name":"Merkhah As Sufla",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/618/7/1091926187.geojson
+++ b/data/109/192/618/7/1091926187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.196895,
-    "geom:area_square_m":2357249434.099799,
+    "geom:area_square_m":2357249247.98326,
     "geom:bbox":"46.189543,14.186353,46.703505,14.864154",
     "geom:latitude":14.484432,
     "geom:longitude":46.486768,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.NI",
         "wd:id":"Q4117809"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893277,
-    "wof:geomhash":"27159c167d1704bf233d866e2c845268",
+    "wof:geomhash":"e32ef24ca9d1675ce45b4064b7f9efba",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926187,
-    "wof:lastmodified":1690924935,
+    "wof:lastmodified":1695886495,
     "wof:name":"Nisab",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/620/5/1091926205.geojson
+++ b/data/109/192/620/5/1091926205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419805,
-    "geom:area_square_m":5036696526.786039,
+    "geom:area_square_m":5036696304.335882,
     "geom:bbox":"47.150935,13.594528,48.579466,14.25388",
     "geom:latitude":14.002749,
     "geom:longitude":47.703263,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.RU",
         "wd:id":"Q4117802"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893279,
-    "wof:geomhash":"5c043af3121a8e67b9d8ecbf55cce152",
+    "wof:geomhash":"75b5f73b9f22335a3ff3e34edd46bc0d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926205,
-    "wof:lastmodified":1690924938,
+    "wof:lastmodified":1695886496,
     "wof:name":"Rudum",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/622/9/1091926229.geojson
+++ b/data/109/192/622/9/1091926229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.254511,
-    "geom:area_square_m":3037619047.93514,
+    "geom:area_square_m":3037619776.460709,
     "geom:bbox":"45.678467,14.830422,46.375319,15.510847",
     "geom:latitude":15.154744,
     "geom:longitude":46.008309,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.SH.US",
         "wd:id":"Q4117697"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893280,
-    "wof:geomhash":"2a54551f9f270614af8bd4ca94964182",
+    "wof:geomhash":"d77392708a058812a07dfeef782d3536",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926229,
-    "wof:lastmodified":1690924983,
+    "wof:lastmodified":1695886506,
     "wof:name":"Usaylan",
     "wof:parent_id":85681011,
     "wof:placetype":"county",

--- a/data/109/192/625/5/1091926255.geojson
+++ b/data/109/192/625/5/1091926255.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.221973,
-    "geom:area_square_m":2679805197.878608,
+    "geom:area_square_m":2679805192.700356,
     "geom:bbox":"53.493263,12.302889,54.542915,12.705389",
     "geom:latitude":12.487733,
     "geom:longitude":53.994808,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SO.HI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893281,
-    "wof:geomhash":"7a15d908c83a9609a6ac06b75ad358db",
+    "wof:geomhash":"1a5cf9d0653180400a40bb74b70f832c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091926255,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Hidaybu",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/628/1/1091926281.geojson
+++ b/data/109/192/628/1/1091926281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.096554,
-    "geom:area_square_m":1165595244.041365,
+    "geom:area_square_m":1165594486.201148,
     "geom:bbox":"52.065361,12.101194,53.749967,12.71125",
     "geom:latitude":12.501834,
     "geom:longitude":53.375413,
@@ -68,9 +68,10 @@
     "wof:concordances":{
         "hasc:id":"YE.SO.QK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893282,
-    "wof:geomhash":"38299e5db9f1c7780540889a36bac6e4",
+    "wof:geomhash":"0602b06f4b0efd0641aee7ce0c91a787",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1091926281,
-    "wof:lastmodified":1627523013,
+    "wof:lastmodified":1695886235,
     "wof:name":"Qulensya Wa Abd Al Kuri",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/109/192/629/7/1091926297.geojson
+++ b/data/109/192/629/7/1091926297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.029461,
-    "geom:area_square_m":354436715.173844,
+    "geom:area_square_m":354436956.199299,
     "geom:bbox":"43.757217,13.273505,44.093424,13.47537",
     "geom:latitude":13.353121,
     "geom:longitude":43.93854,
@@ -96,9 +96,10 @@
         "hasc:id":"YE.TA.MF",
         "wd:id":"Q4117693"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893283,
-    "wof:geomhash":"39150b160f5751bd0c7f58a5d9aacc7e",
+    "wof:geomhash":"4a4ac11ee44f7fe9d7cb0a13c6e9a7a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -108,7 +109,7 @@
         }
     ],
     "wof:id":1091926297,
-    "wof:lastmodified":1690924938,
+    "wof:lastmodified":1695886496,
     "wof:name":"Al Ma'afer",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/632/5/1091926325.geojson
+++ b/data/109/192/632/5/1091926325.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018221,
-    "geom:area_square_m":219259824.191785,
+    "geom:area_square_m":219259799.986438,
     "geom:bbox":"43.980832,13.239005,44.22,13.365775",
     "geom:latitude":13.298382,
     "geom:longitude":44.099329,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.MT",
         "wd:id":"Q4120341"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893284,
-    "wof:geomhash":"eecefc9b55c6fb5a4f498ef2c40d91f3",
+    "wof:geomhash":"23888ccff9eaf6ef27403dcaef4c0a01",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926325,
-    "wof:lastmodified":1690924951,
+    "wof:lastmodified":1695886499,
     "wof:name":"Al Mawasit",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/634/3/1091926343.geojson
+++ b/data/109/192/634/3/1091926343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007929,
-    "geom:area_square_m":95351082.311832,
+    "geom:area_square_m":95350940.355487,
     "geom:bbox":"43.971971,13.40789,44.108828,13.530143",
     "geom:latitude":13.466972,
     "geom:longitude":44.038663,
@@ -104,9 +104,10 @@
         "hasc:id":"YE.TA.MI",
         "wd:id":"Q4118993"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893285,
-    "wof:geomhash":"b1529c3454edd397e7c97c271c6c9edc",
+    "wof:geomhash":"00f5f21efb2a11992715640d34404fc6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1091926343,
-    "wof:lastmodified":1690924940,
+    "wof:lastmodified":1695886496,
     "wof:name":"Al Misrakh",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/635/7/1091926357.geojson
+++ b/data/109/192/635/7/1091926357.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00127,
-    "geom:area_square_m":15261814.524433,
+    "geom:area_square_m":15261734.635756,
     "geom:bbox":"43.967767,13.562127,44.021041,13.608198",
     "geom:latitude":13.58241,
     "geom:longitude":43.994539,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.MU",
         "wd:id":"Q4117614"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893287,
-    "wof:geomhash":"b216a801534cc1c8a9b0f975c50eb16e",
+    "wof:geomhash":"254563130e99d5a9c31710c4e9ca3a09",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926357,
-    "wof:lastmodified":1690924949,
+    "wof:lastmodified":1695886498,
     "wof:name":"Al Mudhaffar",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/637/3/1091926373.geojson
+++ b/data/109/192/637/3/1091926373.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.130857,
-    "geom:area_square_m":1573413527.930551,
+    "geom:area_square_m":1573413805.229595,
     "geom:bbox":"43.237862,13.255498,43.619039,13.797214",
     "geom:latitude":13.492634,
     "geom:longitude":43.412325,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.MK",
         "wd:id":"Q1650840"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893288,
-    "wof:geomhash":"10d8323bc5979ed744564936209deab5",
+    "wof:geomhash":"3cb08b1467188f9d9494afb3b0b4a3bd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926373,
-    "wof:lastmodified":1690925001,
+    "wof:lastmodified":1695886509,
     "wof:name":"Al Mukha",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/639/3/1091926393.geojson
+++ b/data/109/192/639/3/1091926393.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000679,
-    "geom:area_square_m":8157347.220936,
+    "geom:area_square_m":8157417.910678,
     "geom:bbox":"43.992303,13.577219,44.026038,13.609418",
     "geom:latitude":13.59659,
     "geom:longitude":44.011511,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.QA",
         "wd:id":"Q4117619"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893289,
-    "wof:geomhash":"c99d5dd22ab6598a0df0b7cc0aeaefd4",
+    "wof:geomhash":"ef00278982619187e32d35914fc2de9c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926393,
-    "wof:lastmodified":1690925003,
+    "wof:lastmodified":1695886735,
     "wof:name":"Al Qahirah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/641/7/1091926417.geojson
+++ b/data/109/192/641/7/1091926417.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.03638,
-    "geom:area_square_m":438030102.247355,
+    "geom:area_square_m":438030021.662324,
     "geom:bbox":"43.586538,13.070144,43.872167,13.299016",
     "geom:latitude":13.162436,
     "geom:longitude":43.733707,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.WA",
         "wd:id":"Q4117685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893290,
-    "wof:geomhash":"6598be83390c53ff1234ca49d56f78e5",
+    "wof:geomhash":"0ee273d8a84cdc9d281c8481e21d789d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926417,
-    "wof:lastmodified":1690924992,
+    "wof:lastmodified":1695886507,
     "wof:name":"Al Wazi'iyah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/643/9/1091926439.geojson
+++ b/data/109/192/643/9/1091926439.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00682,
-    "geom:area_square_m":82045539.365241,
+    "geom:area_square_m":82045501.322487,
     "geom:bbox":"44.153683,13.28925,44.261136,13.403031",
     "geom:latitude":13.353134,
     "geom:longitude":44.204208,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.SI",
         "wd:id":"Q4118425"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893291,
-    "wof:geomhash":"ac2ca071dbbd799302d3d45629f92f58",
+    "wof:geomhash":"b11f514df8804307ca95029daf08bc5f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926439,
-    "wof:lastmodified":1690924927,
+    "wof:lastmodified":1695886493,
     "wof:name":"As Silw",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/646/3/1091926463.geojson
+++ b/data/109/192/646/3/1091926463.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051529,
-    "geom:area_square_m":620345296.436881,
+    "geom:area_square_m":620345412.417239,
     "geom:bbox":"43.786413,13.071523,44.171182,13.292681",
     "geom:latitude":13.194435,
     "geom:longitude":43.975631,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.SH",
         "wd:id":"Q4165477"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893292,
-    "wof:geomhash":"0016332767fb6dab02e03525dcd4f9d9",
+    "wof:geomhash":"5c387ab27dd235540ba97a11c2646927",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926463,
-    "wof:lastmodified":1690924993,
+    "wof:lastmodified":1695886508,
     "wof:name":"Ash Shamayatayn",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/647/9/1091926479.geojson
+++ b/data/109/192/647/9/1091926479.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050529,
-    "geom:area_square_m":607095590.779914,
+    "geom:area_square_m":607095621.356525,
     "geom:bbox":"43.82235,13.567294,44.199685,13.798941",
     "geom:latitude":13.672371,
     "geom:longitude":44.021148,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.TA",
         "wd:id":"Q1884248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893294,
-    "wof:geomhash":"3684954dae03988d493ed16165bae193",
+    "wof:geomhash":"3cfcb7a015adca50b4f7a4b1db118c3e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926479,
-    "wof:lastmodified":1690924985,
+    "wof:lastmodified":1695886506,
     "wof:name":"At Ta'iziyah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/650/5/1091926505.geojson
+++ b/data/109/192/650/5/1091926505.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.128587,
-    "geom:area_square_m":1548979808.908013,
+    "geom:area_square_m":1548979657.491698,
     "geom:bbox":"43.243267,12.671194,43.703701,13.261298",
     "geom:latitude":13.043366,
     "geom:longitude":43.491902,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.DH",
         "wd:id":"Q4118401"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893295,
-    "wof:geomhash":"a4f0f2ba335119698eff40fa4b6f6a49",
+    "wof:geomhash":"a0d91bb4c04af22e6f73d43ecf8de66f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926505,
-    "wof:lastmodified":1690924956,
+    "wof:lastmodified":1695886500,
     "wof:name":"Dhubab",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/652/5/1091926525.geojson
+++ b/data/109/192/652/5/1091926525.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038376,
-    "geom:area_square_m":461511368.557998,
+    "geom:area_square_m":461511331.340573,
     "geom:bbox":"44.082155,13.315403,44.424752,13.562667",
     "geom:latitude":13.448912,
     "geom:longitude":44.241026,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.DK",
         "wd:id":"Q4118319"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893296,
-    "wof:geomhash":"ee5473e5bb77dd8309fa51e8865c3ffa",
+    "wof:geomhash":"6c611a9dfea8207b5a0c3617e9bd1edb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926525,
-    "wof:lastmodified":1690924998,
+    "wof:lastmodified":1695886509,
     "wof:name":"Dimnat Khadir",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/654/3/1091926543.geojson
+++ b/data/109/192/654/3/1091926543.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015567,
-    "geom:area_square_m":187343705.478989,
+    "geom:area_square_m":187343657.640638,
     "geom:bbox":"44.178588,13.205509,44.340071,13.375758",
     "geom:latitude":13.272885,
     "geom:longitude":44.267149,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.HA",
         "wd:id":"Q4118985"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893297,
-    "wof:geomhash":"dc11e9a3fb4d45e12c275d8a328f72cb",
+    "wof:geomhash":"09ae2ad5aa3a96b3567c7e305f9d3cf7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926543,
-    "wof:lastmodified":1690925006,
+    "wof:lastmodified":1695886510,
     "wof:name":"Hayfan",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/655/5/1091926555.geojson
+++ b/data/109/192/655/5/1091926555.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025895,
-    "geom:area_square_m":311387353.62131,
+    "geom:area_square_m":311386981.26795,
     "geom:bbox":"43.788404,13.358734,43.976054,13.573791",
     "geom:latitude":13.471523,
     "geom:longitude":43.882241,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.JH",
         "wd:id":"Q4119006"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893299,
-    "wof:geomhash":"fdc3c022b975b71629cb87e5298d0afc",
+    "wof:geomhash":"a38c379653c4cce38882a32916a5d1d2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926555,
-    "wof:lastmodified":1690924996,
+    "wof:lastmodified":1695886508,
     "wof:name":"Jabal Habashy",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/657/3/1091926573.geojson
+++ b/data/109/192/657/3/1091926573.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.101088,
-    "geom:area_square_m":1214748688.198907,
+    "geom:area_square_m":1214749082.961291,
     "geom:bbox":"43.469773,13.329368,43.865318,13.915706",
     "geom:latitude":13.633813,
     "geom:longitude":43.668133,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.MQ",
         "wd:id":"Q4118981"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893300,
-    "wof:geomhash":"d2ceb348b2fec99450d1f0b204d944a1",
+    "wof:geomhash":"beea3b65ec7f59ca4b14e178950a2613",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926573,
-    "wof:lastmodified":1690924954,
+    "wof:lastmodified":1695886500,
     "wof:name":"Maqbanah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/658/9/1091926589.geojson
+++ b/data/109/192/658/9/1091926589.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001088,
-    "geom:area_square_m":13083547.02368,
+    "geom:area_square_m":13083487.925332,
     "geom:bbox":"43.980396,13.517357,44.016538,13.565732",
     "geom:latitude":13.537006,
     "geom:longitude":43.997137,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.MH",
         "wd:id":"Q4118869"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893301,
-    "wof:geomhash":"474e4468be3f63c5e647e401163775dc",
+    "wof:geomhash":"8cacb352b1ea21bf976a21de3a46a3a3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926589,
-    "wof:lastmodified":1690924946,
+    "wof:lastmodified":1695886498,
     "wof:name":"Mashra'a Wa Hadnan",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/660/7/1091926607.geojson
+++ b/data/109/192/660/7/1091926607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.05909,
-    "geom:area_square_m":710154064.038327,
+    "geom:area_square_m":710154377.23472,
     "geom:bbox":"44.123977,13.458911,44.518747,13.774324",
     "geom:latitude":13.607808,
     "geom:longitude":44.321176,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.MW",
         "wd:id":"Q4117789"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893302,
-    "wof:geomhash":"8327c050829272f5fe2a9117dee1bfdc",
+    "wof:geomhash":"44948b2062dd53e9f83b7e6c9ac5db7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926607,
-    "wof:lastmodified":1690924945,
+    "wof:lastmodified":1695886498,
     "wof:name":"Mawiyah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/662/3/1091926623.geojson
+++ b/data/109/192/662/3/1091926623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016107,
-    "geom:area_square_m":193641338.07994,
+    "geom:area_square_m":193641141.770753,
     "geom:bbox":"43.935922,13.439202,44.157752,13.604052",
     "geom:latitude":13.531635,
     "geom:longitude":44.05304,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.SM",
         "wd:id":"Q4118385"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893303,
-    "wof:geomhash":"6c253c961e7bfd796ef671485bf2f2fa",
+    "wof:geomhash":"20ba877a8a04900e5958ab5bb3da9937",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926623,
-    "wof:lastmodified":1690925005,
+    "wof:lastmodified":1695886510,
     "wof:name":"Sabir Al Mawadim",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/663/9/1091926639.geojson
+++ b/data/109/192/663/9/1091926639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001434,
-    "geom:area_square_m":17236992.458429,
+    "geom:area_square_m":17237113.108433,
     "geom:bbox":"44.019443,13.55819,44.066044,13.60407",
     "geom:latitude":13.580571,
     "geom:longitude":44.039543,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.SL",
         "wd:id":"Q4117815"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893304,
-    "wof:geomhash":"082d331d9da81e930f5f085d2482ef4f",
+    "wof:geomhash":"4d3b11d53dca6b74f76cfb421bc5e97e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926639,
-    "wof:lastmodified":1690924999,
+    "wof:lastmodified":1695886509,
     "wof:name":"Salh",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/665/5/1091926655.geojson
+++ b/data/109/192/665/5/1091926655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004804,
-    "geom:area_square_m":57791113.639101,
+    "geom:area_square_m":57791113.639091,
     "geom:bbox":"44.0600910373,13.3477811725,44.1756504908,13.4129524295",
     "geom:latitude":13.38386,
     "geom:longitude":44.123869,
@@ -97,9 +97,10 @@
     "wof:concordances":{
         "hasc:id":"YE.TA.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893305,
-    "wof:geomhash":"41c7dc42ef5c2ddb23da0c8054384dff",
+    "wof:geomhash":"5751fd83e103f4f21f93c9c132a3d0c0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1091926655,
-    "wof:lastmodified":1566660287,
+    "wof:lastmodified":1695886510,
     "wof:name":"Sama",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/667/5/1091926675.geojson
+++ b/data/109/192/667/5/1091926675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.034904,
-    "geom:area_square_m":419218175.565235,
+    "geom:area_square_m":419218231.004505,
     "geom:bbox":"43.623316,13.580216,43.912795,13.883157",
     "geom:latitude":13.751701,
     "geom:longitude":43.774103,
@@ -95,9 +95,10 @@
         "hasc:id":"YE.TA.SR",
         "wd:id":"Q4120339"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893307,
-    "wof:geomhash":"2d00c5dd8fdbf3007bd95fcd4d4b2e16",
+    "wof:geomhash":"b288dcb4fc670583060c8ed7ede3e270",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1091926675,
-    "wof:lastmodified":1690924947,
+    "wof:lastmodified":1695886498,
     "wof:name":"Shara'b Ar Rawnah",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/669/1/1091926691.geojson
+++ b/data/109/192/669/1/1091926691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.016733,
-    "geom:area_square_m":200945944.268056,
+    "geom:area_square_m":200945535.15149,
     "geom:bbox":"43.787665,13.677152,43.981372,13.893108",
     "geom:latitude":13.791753,
     "geom:longitude":43.894098,
@@ -101,9 +101,10 @@
         "hasc:id":"YE.TA.SS",
         "wd:id":"Q4120340"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893308,
-    "wof:geomhash":"6719da70bf0e41acc635cc709b180997",
+    "wof:geomhash":"8974285208e09b7391ed55dd60621708",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1091926691,
-    "wof:lastmodified":1690924944,
+    "wof:lastmodified":1695886497,
     "wof:name":"Shara'b As Salam",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/109/192/670/7/1091926707.geojson
+++ b/data/109/192/670/7/1091926707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056885,
-    "geom:area_square_m":684321694.898846,
+    "geom:area_square_m":684321383.826311,
     "geom:bbox":"43.45775,13.171437,43.774082,13.586143",
     "geom:latitude":13.374798,
     "geom:longitude":43.607401,
@@ -98,9 +98,10 @@
         "hasc:id":"YE.TA.MZ",
         "wd:id":"Q4118996"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1473893309,
-    "wof:geomhash":"bcc16c91503a9fec9087246873cde069",
+    "wof:geomhash":"3f340b21141ee422c89bd8a8a3c15930",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1091926707,
-    "wof:lastmodified":1690924994,
+    "wof:lastmodified":1695886508,
     "wof:name":"Mawza",
     "wof:parent_id":85680989,
     "wof:placetype":"county",

--- a/data/110/880/568/1/1108805681.geojson
+++ b/data/110/880/568/1/1108805681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318527,
-    "geom:area_square_m":3845400441.920049,
+    "geom:area_square_m":3845400441.92013,
     "geom:bbox":"52.065361023,12.101194382,54.542915344,12.711250305",
     "geom:latitude":12.492008,
     "geom:longitude":53.807053,
@@ -273,11 +273,13 @@
     "wof:concordances":{
         "fips:code":"YM28",
         "hasc:id":"YE.SO",
+        "iso:code":"YE-SU",
         "iso:id":"YE-SU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:created":1485820050,
-    "wof:geomhash":"99f2e8da7fa9a8c8370162a3b2b4f8d6",
+    "wof:geomhash":"b0e4b75f6c0fda2bcf3eeb14cf3cf4d6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -292,7 +294,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566659868,
+    "wof:lastmodified":1695884328,
     "wof:name":"Socotra",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/421/174/007/421174007.geojson
+++ b/data/421/174/007/421174007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052533,
-    "geom:area_square_m":629575957.084637,
+    "geom:area_square_m":629576134.071324,
     "geom:bbox":"43.114124,13.978952,43.500031,14.383207",
     "geom:latitude":14.25687,
     "geom:longitude":43.351326,
@@ -246,12 +246,13 @@
         "wd:id":"Q4117562",
         "wk:page":"Zab\u012bd"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1459009017,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e228efbed741071b3edc5fc5b3fba507",
+    "wof:geomhash":"b53b1b6da69a6d71dfefd84d469a0230",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -261,7 +262,7 @@
         }
     ],
     "wof:id":421174007,
-    "wof:lastmodified":1690925050,
+    "wof:lastmodified":1695886713,
     "wof:name":"Zabid",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/421/183/315/421183315.geojson
+++ b/data/421/183/315/421183315.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.137266,
-    "geom:area_square_m":1639012206.247175,
+    "geom:area_square_m":1639011660.653762,
     "geom:bbox":"42.84927,14.864288,43.507377,15.229985",
     "geom:latitude":15.061175,
     "geom:longitude":43.158892,
@@ -133,12 +133,13 @@
         "qs_pg:id":972337,
         "wd:id":"Q2217814"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1459009365,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9cdae9bb731c6272e2750746cd335bb6",
+    "wof:geomhash":"ac6b6d5c80a545bcf38b9ef12b5a172d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -148,7 +149,7 @@
         }
     ],
     "wof:id":421183315,
-    "wof:lastmodified":1690925055,
+    "wof:lastmodified":1695886713,
     "wof:name":"Bajil",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/421/202/517/421202517.geojson
+++ b/data/421/202/517/421202517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.127974,
-    "geom:area_square_m":1532251933.269413,
+    "geom:area_square_m":1532252224.831376,
     "geom:bbox":"43.012302,14.262544,43.548327,14.656863",
     "geom:latitude":14.466804,
     "geom:longitude":43.289929,
@@ -159,12 +159,13 @@
         "wd:id":"Q579291",
         "wk:page":"Bayt al-Faqih"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"YE",
     "wof:created":1459010120,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1a08df28dc5ece6a8b0c35d4636073ef",
+    "wof:geomhash":"b3457a575143d012b2da308147c050d9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":421202517,
-    "wof:lastmodified":1690925048,
+    "wof:lastmodified":1695886713,
     "wof:name":"Bayt Al Faqiah",
     "wof:parent_id":85680959,
     "wof:placetype":"county",

--- a/data/856/324/99/85632499.geojson
+++ b/data/856/324/99/85632499.geojson
@@ -1183,6 +1183,7 @@
         "hasc:id":"YE",
         "icao:code":"6O",
         "ioc:id":"YEM",
+        "iso:code":"YE",
         "itu:id":"YEM",
         "loc:id":"n81053408",
         "m49:code":"887",
@@ -1197,6 +1198,7 @@
         "wk:page":"Yemen",
         "wmo:id":"YE"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:country_alpha3":"YEM",
     "wof:geom_alt":[
@@ -1219,7 +1221,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639521,
+    "wof:lastmodified":1695881176,
     "wof:name":"Yemen",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/809/55/85680955.geojson
+++ b/data/856/809/55/85680955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.053243,
-    "geom:area_square_m":12448303410.738752,
+    "geom:area_square_m":12448303726.8897,
     "geom:bbox":"43.137924,16.609793,44.890749,17.565833",
     "geom:latitude":17.091498,
     "geom:longitude":43.910594,
@@ -358,15 +358,17 @@
         "gn:id":71333,
         "gp:id":20070038,
         "hasc:id":"YE.SD",
+        "iso:code":"YE-SD",
         "iso:id":"YE-SD",
         "qs_pg:id":332052,
         "wd:id":"Q275732"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a07697a67c47dc7a4a0879efcf67d8c0",
+    "wof:geomhash":"66051e864b4d56334991e2432f5f796d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -381,7 +383,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924905,
+    "wof:lastmodified":1695884851,
     "wof:name":"Sa`dah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/59/85680959.geojson
+++ b/data/856/809/59/85680959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.106233,
-    "geom:area_square_m":13222474075.251263,
+    "geom:area_square_m":13222474955.253222,
     "geom:bbox":"41.822861,13.649555,43.775478,15.876133",
     "geom:latitude":14.829638,
     "geom:longitude":43.168118,
@@ -309,15 +309,17 @@
         "gn:id":79416,
         "gp:id":20070047,
         "hasc:id":"YE.HU",
+        "iso:code":"YE-HU",
         "iso:id":"YE-HU",
         "qs_pg:id":236291,
         "wd:id":"Q275755"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0bef72a4a3b773fc60221901ee5c1a9a",
+    "wof:geomhash":"6e6d44abd1cadc6e0c815be373e44aea",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924902,
+    "wof:lastmodified":1695884356,
     "wof:name":"Al Hudaydah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/65/85680965.geojson
+++ b/data/856/809/65/85680965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195879,
-    "geom:area_square_m":2335399880.644507,
+    "geom:area_square_m":2335399866.42509,
     "geom:bbox":"43.239006,15.045284,43.915297,15.569917",
     "geom:latitude":15.374033,
     "geom:longitude":43.541861,
@@ -302,16 +302,18 @@
         "gn:id":73200,
         "gp:id":20070046,
         "hasc:id":"YE.MW",
+        "iso:code":"YE-MW",
         "iso:id":"YE-MW",
         "qs_pg:id":1062877,
         "wd:id":"Q388280",
         "wk:page":"Al Mahwit Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ebfb0a0b492a335c5f0e4d2a9547f38f",
+    "wof:geomhash":"35aec4032d0a189c1d818b9252431866",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924904,
+    "wof:lastmodified":1695884547,
     "wof:name":"Al Mahwit",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/69/85680969.geojson
+++ b/data/856/809/69/85680969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.636798,
-    "geom:area_square_m":7619871617.656599,
+    "geom:area_square_m":7619871049.443704,
     "geom:bbox":"43.476472,14.067596,44.836852,15.018695",
     "geom:latitude":14.598491,
     "geom:longitude":44.200574,
@@ -322,16 +322,18 @@
         "gn:id":76183,
         "gp:id":20070044,
         "hasc:id":"YE.DH",
+        "iso:code":"YE-DH",
         "iso:id":"YE-DH",
         "qs_pg:id":984834,
         "unlc:id":"YE-DH",
         "wd:id":"Q328193"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9b233dcdb3c16121e9dcdb983660efd2",
+    "wof:geomhash":"e582fe592db74ca34379585eef0c8d58",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924903,
+    "wof:lastmodified":1695884547,
     "wof:name":"Dhamar",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/73/85680973.geojson
+++ b/data/856/809/73/85680973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.700104,
-    "geom:area_square_m":8317663746.813425,
+    "geom:area_square_m":8317663460.027659,
     "geom:bbox":"42.190388,15.510535,43.757324,16.67725",
     "geom:latitude":16.091105,
     "geom:longitude":43.264417,
@@ -309,16 +309,18 @@
         "gn:id":6201195,
         "gp:id":20070048,
         "hasc:id":"YE.HJ",
+        "iso:code":"YE-HJ",
         "iso:id":"YE-HJ",
         "qs_pg:id":219899,
         "wd:id":"Q328158",
         "wk:page":"Hajjah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0675fb3a432b86931e518de6f26715a2",
+    "wof:geomhash":"9ae1a6175d9c3637226dcbe7589e6ca8",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924904,
+    "wof:lastmodified":1695884851,
     "wof:name":"Hajjah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/77/85680977.geojson
+++ b/data/856/809/77/85680977.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.667514,
-    "geom:area_square_m":7927172911.381708,
+    "geom:area_square_m":7927173314.469816,
     "geom:bbox":"43.50934,15.531039,44.349575,16.691634",
     "geom:latitude":16.173327,
     "geom:longitude":43.907612,
@@ -336,17 +336,19 @@
         "gn:id":6201194,
         "gp:id":56189859,
         "hasc:id":"YE.AM",
+        "iso:code":"YE-AM",
         "iso:id":"YE-AM",
         "qs_pg:id":1096166,
         "unlc:id":"YE-AM",
         "wd:id":"Q275720",
         "wk:page":"'Amran Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b71aaedc66c7c0bea9f58c119a6aec7a",
+    "wof:geomhash":"661821083f80b37b200f83c2386e3023",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924906,
+    "wof:lastmodified":1695884547,
     "wof:name":"Amran",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/79/85680979.geojson
+++ b/data/856/809/79/85680979.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.447318,
-    "geom:area_square_m":5365068993.323184,
+    "geom:area_square_m":5365069316.271921,
     "geom:bbox":"43.650512,13.703592,44.681302,14.464129",
     "geom:latitude":14.07592,
     "geom:longitude":44.166817,
@@ -312,17 +312,19 @@
         "gn:id":6201196,
         "gp:id":20070042,
         "hasc:id":"YE.IB",
+        "iso:code":"YE-IB",
         "iso:id":"YE-IB",
         "qs_pg:id":1287578,
         "unlc:id":"YE-IB",
         "wd:id":"Q388274",
         "wk:page":"Ibb Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"34192956ac78da222741baa3bb55b6b2",
+    "wof:geomhash":"4a0d6d5c55341bdb3bfc0dc0e41b9875",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924905,
+    "wof:lastmodified":1695884851,
     "wof:name":"Ibb",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/85/85680985.geojson
+++ b/data/856/809/85/85680985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.053879,
-    "geom:area_square_m":12687948376.538206,
+    "geom:area_square_m":12687949057.853233,
     "geom:bbox":"43.526265,12.593611,45.386495,14.05713",
     "geom:latitude":13.180077,
     "geom:longitude":44.55327,
@@ -270,16 +270,18 @@
         "gn:id":6201197,
         "gp:id":20070040,
         "hasc:id":"YE.LA",
+        "iso:code":"YE-LA",
         "iso:id":"YE-LA",
         "qs_pg:id":1085799,
         "wd:id":"Q388318",
         "wk:page":"Lahij Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"345a9c2eb516c20bf686845dbef44daa",
+    "wof:geomhash":"1d5afcccb5399424062b89ba392cc3ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924906,
+    "wof:lastmodified":1695884851,
     "wof:name":"Lahij",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/89/85680989.geojson
+++ b/data/856/809/89/85680989.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.834234,
-    "geom:area_square_m":10033760634.920488,
+    "geom:area_square_m":10033760198.687044,
     "geom:bbox":"43.237862,12.671194,44.518747,13.915706",
     "geom:latitude":13.418758,
     "geom:longitude":43.778108,
@@ -323,15 +323,17 @@
         "gn:id":70222,
         "gp:id":20070041,
         "hasc:id":"YE.TA",
+        "iso:code":"YE-TA",
         "iso:id":"YE-TA",
         "qs_pg:id":236289,
         "wd:id":"Q388330"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a22a178385468c326d82dd9fd2e30945",
+    "wof:geomhash":"e9a00dcb5615dd43749dbb694be15b42",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924903,
+    "wof:lastmodified":1695884356,
     "wof:name":"Ta`izz",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/809/95/85680995.geojson
+++ b/data/856/809/95/85680995.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.634443,
-    "geom:area_square_m":66708398928.988205,
+    "geom:area_square_m":66708399127.880493,
     "geom:bbox":"50.129217,15.080389,53.109085,18.999633",
     "geom:latitude":16.735651,
     "geom:longitude":51.591113,
@@ -312,17 +312,19 @@
         "gn:id":78985,
         "gp:id":20070032,
         "hasc:id":"YE.MR",
+        "iso:code":"YE-MR",
         "iso:id":"YE-MR",
         "qs_pg:id":1149772,
         "unlc:id":"YE-MR",
         "wd:id":"Q275752",
         "wk:page":"Al Mahrah Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5a7d822b48b6f55c5fcb4646d396e3cf",
+    "wof:geomhash":"62625bee8873f580b62b098b197bfe65",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924901,
+    "wof:lastmodified":1695884547,
     "wof:name":"Al Mahrah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/01/85681001.geojson
+++ b/data/856/810/01/85681001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.777303,
-    "geom:area_square_m":9312981981.864487,
+    "geom:area_square_m":9312982167.815271,
     "geom:bbox":"44.587367,13.83133,46.060328,14.823668",
     "geom:latitude":14.315819,
     "geom:longitude":45.347087,
@@ -325,16 +325,18 @@
         "gn:id":79838,
         "gp:id":20070043,
         "hasc:id":"YE.BA",
+        "iso:code":"YE-BA",
         "iso:id":"YE-BA",
         "qs_pg:id":895522,
         "unlc:id":"YE-BA",
         "wd:id":"Q221212"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6cc107d33ad0548e154241438553f2be",
+    "wof:geomhash":"f4a31c3fad2ab4ee3df5ed5e002d8461",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924898,
+    "wof:lastmodified":1695884547,
     "wof:name":"Al Bayda'",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/03/85681003.geojson
+++ b/data/856/810/03/85681003.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.334259,
-    "geom:area_square_m":4012155516.327896,
+    "geom:area_square_m":4012155315.982324,
     "geom:bbox":"44.368436,13.549716,45.15498,14.234677",
     "geom:latitude":13.898617,
     "geom:longitude":44.75816,
@@ -145,13 +145,15 @@
         "gn:id":6201193,
         "gp:id":-20070040,
         "hasc:id":"YE.DL",
+        "iso:code":"YE-DA",
         "iso:id":"YE-DA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"64e97d5d258174a8fae91066587b95e2",
+    "wof:geomhash":"126b9fa651fc89d7c5d13c7b91bff731",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -166,7 +168,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614896589,
+    "wof:lastmodified":1695884546,
     "wof:name":"Al Dali'",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/07/85681007.geojson
+++ b/data/856/810/07/85681007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.34688,
-    "geom:area_square_m":39654725296.531982,
+    "geom:area_square_m":39654724956.208916,
     "geom:bbox":"44.051953,15.760067,47.001414,17.433535",
     "geom:latitude":16.621514,
     "geom:longitude":45.600025,
@@ -312,17 +312,19 @@
         "gn:id":74222,
         "gp:id":20070039,
         "hasc:id":"YE.JA",
+        "iso:code":"YE-JA",
         "iso:id":"YE-JA",
         "qs_pg:id":1149773,
         "unlc:id":"YE-JA",
         "wd:id":"Q328128",
         "wk:page":"Al Jawf Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"eed17a97e3b06d326e87f9845e10f4e8",
+    "wof:geomhash":"0ed81a5377bfb781eb28c6ef162803c3",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924898,
+    "wof:lastmodified":1695884851,
     "wof:name":"Al Jawf",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/11/85681011.geojson
+++ b/data/856/810/11/85681011.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.265481,
-    "geom:area_square_m":39042169592.7603,
+    "geom:area_square_m":39042169705.701363,
     "geom:bbox":"45.475895,13.594528,48.579466,15.72159",
     "geom:latitude":14.772576,
     "geom:longitude":46.887605,
@@ -327,16 +327,18 @@
         "gn:id":70935,
         "gp:id":20070034,
         "hasc:id":"YE.SH",
+        "iso:code":"YE-SH",
         "iso:id":"YE-SH",
         "qs_pg:id":495943,
         "unlc:id":"YE-SH",
         "wd:id":"Q328180"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ea180af0d86edaff24bc32bd8f90da5",
+    "wof:geomhash":"cb60b574e5a9a126d6daf20bfce66419",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924896,
+    "wof:lastmodified":1695884546,
     "wof:name":"Shabwah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/15/85681015.geojson
+++ b/data/856/810/15/85681015.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.473825,
-    "geom:area_square_m":17561517088.680782,
+    "geom:area_square_m":17561517142.448494,
     "geom:bbox":"44.516259,14.504966,46.803467,16.160865",
     "geom:latitude":15.493186,
     "geom:longitude":45.515799,
@@ -384,16 +384,18 @@
         "gn:id":72966,
         "gp:id":20070037,
         "hasc:id":"YE.MA",
+        "iso:code":"YE-MA",
         "iso:id":"YE-MA",
         "qs_pg:id":236288,
         "unlc:id":"YE-MA",
         "wd:id":"Q498465"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"597b344fdb3252a3cd4a36cfcfdc1a89",
+    "wof:geomhash":"6f8c27470b352d47b800f58703f445e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -408,7 +410,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924899,
+    "wof:lastmodified":1695884547,
     "wof:name":"Ma'rib",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/21/85681021.geojson
+++ b/data/856/810/21/85681021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.03581,
-    "geom:area_square_m":12351584571.118765,
+    "geom:area_square_m":12351584379.659918,
     "geom:bbox":"43.506874,14.747906,45.108608,16.045959",
     "geom:latitude":15.338898,
     "geom:longitude":44.338049,
@@ -267,15 +267,17 @@
         "gn:id":71132,
         "gp:id":20070045,
         "hasc:id":"YE.NA",
+        "iso:code":"YE-SN",
         "iso:id":"YE-SN",
         "qs_pg:id":236290,
         "wd:id":"Q388291"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09534486f943828a0d7688b6b84e4744",
+    "wof:geomhash":"8c5f5f4facf19ae468323c8d42f0598a",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -290,7 +292,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924897,
+    "wof:lastmodified":1695884547,
     "wof:name":"Sana'a",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/25/85681025.geojson
+++ b/data/856/810/25/85681025.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":13.794594,
-    "geom:area_square_m":163367723403.848724,
+    "geom:area_square_m":163367723926.28949,
     "geom:bbox":"46.311862,14.03625,51.963401,18.993773",
     "geom:latitude":16.670624,
     "geom:longitude":49.155708,
@@ -314,16 +314,18 @@
         "gn:id":75411,
         "gp:id":20070033,
         "hasc:id":"YE.HA",
+        "iso:code":"YE-HD",
         "iso:id":"YE-HD",
         "qs_pg:id":1085798,
         "wd:id":"Q241135",
         "wk:page":"Hadhramaut Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"8c840694e90eb12006506373e5fafd83",
+    "wof:geomhash":"a736801c84da9e0ddf70a6844c30a00f",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924900,
+    "wof:lastmodified":1695884547,
     "wof:name":"Hadramawt",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/29/85681029.geojson
+++ b/data/856/810/29/85681029.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032642,
-    "geom:area_square_m":389010652.639242,
+    "geom:area_square_m":389011046.545255,
     "geom:bbox":"44.120851,15.291572,44.401989,15.611423",
     "geom:latitude":15.463615,
     "geom:longitude":44.237884,
@@ -139,14 +139,16 @@
         "gn:id":6940571,
         "gp:id":56189858,
         "hasc:id":"YE.SA",
+        "iso:code":"YE-SA",
         "iso:id":"YE-SA",
         "qs_pg:id":892970
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"96b784fdbaff0f9014f4a293ede52968",
+    "wof:geomhash":"43f825b02695f9178d4a7fdb2559178d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -161,7 +163,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1614896589,
+    "wof:lastmodified":1695884547,
     "wof:name":"Amanat Al Asimah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/33/85681033.geojson
+++ b/data/856/810/33/85681033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.15904,
-    "geom:area_square_m":1902533501.999616,
+    "geom:area_square_m":1902533779.440289,
     "geom:bbox":"43.467794,14.369233,43.934272,14.950279",
     "geom:latitude":14.660481,
     "geom:longitude":43.670554,
@@ -315,15 +315,17 @@
         "gn:id":71532,
         "gp:id":-20070045,
         "hasc:id":"YE.RM",
+        "iso:code":"YE-RA",
         "iso:id":"YE-RA",
         "unlc:id":"YE-RA",
         "wd:id":"Q475033"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d9cf907552834a13b0db4beaf2ffea7c",
+    "wof:geomhash":"a3435689f6c658bf9433521e64a7ef83",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924895,
+    "wof:lastmodified":1695884547,
     "wof:name":"Raymah",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/39/85681039.geojson
+++ b/data/856/810/39/85681039.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062843,
-    "geom:area_square_m":757670380.257677,
+    "geom:area_square_m":757670020.659424,
     "geom:bbox":"43.388668,12.631222,45.10085,12.943596",
     "geom:latitude":12.827238,
     "geom:longitude":44.78392,
@@ -310,16 +310,18 @@
         "gn:id":80412,
         "gp:id":20070035,
         "hasc:id":"YE.AD",
+        "iso:code":"YE-AD",
         "iso:id":"YE-AD",
         "qs_pg:id":1084686,
         "unlc:id":"YE-AD",
         "wd:id":"Q275729"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5af30e6735eefbbd8219945d1972c397",
+    "wof:geomhash":"38c5d477e3cd777b08dd87b064ddf7db",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -334,7 +336,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924899,
+    "wof:lastmodified":1695884851,
     "wof:name":"`Adan",
     "wof:parent_id":85632499,
     "wof:placetype":"region",

--- a/data/856/810/43/85681043.geojson
+++ b/data/856/810/43/85681043.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.370235,
-    "geom:area_square_m":16460236002.933954,
+    "geom:area_square_m":16460235622.538074,
     "geom:bbox":"45.067702,12.935917,47.186712,14.31929",
     "geom:latitude":13.710846,
     "geom:longitude":46.163834,
@@ -327,17 +327,19 @@
         "gn:id":80425,
         "gp:id":20070036,
         "hasc:id":"YE.AB",
+        "iso:code":"YE-AB",
         "iso:id":"YE-AB",
         "qs_pg:id":8552,
         "unlc:id":"YE-AB",
         "wd:id":"Q241774",
         "wk:page":"Abyan Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"YE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"47b4442edce2779094bea0a3a85013b5",
+    "wof:geomhash":"833fd58f8779e04937ca47043ab3f4f7",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -352,7 +354,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690924897,
+    "wof:lastmodified":1695884547,
     "wof:name":"Abyan",
     "wof:parent_id":85632499,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.